### PR TITLE
L0 automation + sign-up form polish + Sybil guard

### DIFF
--- a/.github/ISSUE_TEMPLATE/signup.yml
+++ b/.github/ISSUE_TEMPLATE/signup.yml
@@ -10,8 +10,6 @@ body:
 
         Enter your **0G mainnet EVM wallet** below; it is your payout address. This is a **public** repo, so the address is visible — that is expected. **Never paste a private key or seed phrase** — only the public wallet address.
 
-        > Your **reward level is decided by triage** from your accepted, deduped bugs. The level and progress fields below are your own intent and checklist — not the source of truth. See [LEVELS.md](./LEVELS.md).
-
   - type: input
     id: wallet
     attributes:

--- a/.github/ISSUE_TEMPLATE/signup.yml
+++ b/.github/ISSUE_TEMPLATE/signup.yml
@@ -8,6 +8,8 @@ body:
       value: |
         Opening this issue registers you and becomes **your personal tracker**. Your **GitHub account** — whoever opens this issue — is your identity and the join key for every reward, read automatically so there is nothing to type and nothing to mismatch.
 
+        **Title:** add your GitHub username after `[signup]:` — e.g. `[signup]: your-github-username`.
+
         Enter your **0G mainnet EVM wallet** below; it is your payout address. This is a **public** repo, so the address is visible — that is expected. **Never paste a private key or seed phrase** — only the public wallet address.
 
   - type: input

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -58,3 +58,20 @@
   description: "Auto-labeller could not derive area/severity from the form — triage by hand"
 # `rc:<CODE>` labels (e.g. rc:CHAIN_ID_MISSING) are created on demand at triage
 # to group every issue sharing a root cause. See .github/TRIAGE.md.
+
+# --- Sign-up & L0 (GitHub-native registration + feedback tracking) ---
+- name: "signup"
+  color: "0e8a16"
+  description: "Testing sign-up issue — the tester's authenticated identity + wallet"
+- name: "needs:fix"
+  color: "d4c5f9"
+  description: "Sign-up needs a correction (invalid wallet, or a secret pasted)"
+- name: "l0:studio-done"
+  color: "c2e0c6"
+  description: "0G Studio Feedback submitted (set by the Google Forms bridge)"
+- name: "l0:pc-done"
+  color: "c2e0c6"
+  description: "0G Private Computer Feedback submitted (set by the Google Forms bridge)"
+- name: "l0:cleared"
+  color: "0e8a16"
+  description: "Both L0 feedback forms received — L0 Recruit cleared"

--- a/.github/workflows/mark-l0-cleared.yml
+++ b/.github/workflows/mark-l0-cleared.yml
@@ -1,0 +1,48 @@
+name: Mark L0 cleared
+
+# The Google Forms bridge (automation/l0-feedback-bridge.gs) adds `l0:studio-done`
+# and `l0:pc-done` to a tester's sign-up issue as each feedback form comes in.
+# When both are present, this sets `l0:cleared` (and tells the tester), so L0
+# completion is visible on the sign-up issue and readable by the reward export.
+#
+# Default GITHUB_TOKEN is enough — it only labels/comments issues in this repo.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  combine:
+    if: >-
+      contains(github.event.issue.labels.*.name, 'signup') &&
+      (github.event.label.name == 'l0:studio-done' || github.event.label.name == 'l0:pc-done')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+    steps:
+      - name: Set l0:cleared once both feedback forms are in
+        run: |
+          set -euo pipefail
+
+          LABELS=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name' | tr '\n' ' ')
+          has() { case " $LABELS " in *" $1 "*) return 0 ;; *) return 1 ;; esac }
+
+          if ! { has "l0:studio-done" && has "l0:pc-done"; }; then
+            echo "Only one feedback label so far — waiting for the other."
+            exit 0
+          fi
+
+          if has "l0:cleared"; then
+            echo "Already cleared."
+            exit 0
+          fi
+
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "l0:cleared" >/dev/null
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "🎉 **L0 Recruit cleared** — both feedback forms received. That's **10 0G Compute Credit**. Climb to L1 by filing an accepted **App Suite** bug — see the [README](../../blob/main/README.md)."
+          echo "Marked #$ISSUE_NUMBER l0:cleared."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ All rewards are **0G Compute Credit**; payout = the Credit of the **highest leve
 
 Track filed issues on the [Defect board #19](https://github.com/orgs/0gfoundation/projects/19). The more **accepted, deduped** defects a tester surfaces, the higher they climb - Master is the cap. Ecosystem dApps are **record-only**: log coverage, not a reward gate.
 
+Two GitHub issue forms drive the program: **`signup.yml`** (label `signup` — step 0, identity + wallet, handled by `confirm-signup.yml`) and **`defect-report.yml`** (labels `defect` + `status:filed` — steps 2–4, one bug/coverage log per issue, handled by `add-defects-to-board.yml` + `notify-status-change.yml`). Step 1's L0 feedback is two external Google forms (see `config.yml` contact links), not GitHub issues.
+
 ```json
 {
   "signup": "https://github.com/0gfoundation/0g-testing-hub/issues/new?template=signup.yml&labels=signup",

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ All rewards are **0G Compute Credit**; payout = the Credit of your **highest lev
 
 Track your filed issues on the [Defect board #19](https://github.com/orgs/0gfoundation/projects/19). The more **accepted, deduped** defects you surface, the higher you climb - Master is the cap.
 
+Two GitHub issue forms drive this: **[Sign up](https://github.com/0gfoundation/0g-testing-hub/issues/new?template=signup.yml&labels=signup)** (step 0 — identity + wallet) and **[Defect report](https://github.com/0gfoundation/0g-testing-hub/issues/new?template=defect-report.yml&labels=defect,status:filed)** (steps 2–4 — one bug or coverage log per issue). Step 1's L0 feedback is the two external Google forms above.
+
 **Won't be accepted / out of bounds:**
 
 - **Duplicates** or **not-reproducible** "felt off" reports.

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,45 @@
+# Automation — L0 feedback bridge
+
+Makes **L0 completion automatic and visible** without owning anything outside GitHub +
+the two feedback forms you administer. No more manual cross-referencing of form exports.
+
+## How it flows
+
+```
+Tester submits a feedback form
+  └─ Apps Script (l0-feedback-bridge.gs) on the form
+       └─ finds the tester's GitHub sign-up issue (by GitHub username)
+            └─ adds l0:studio-done  OR  l0:pc-done
+                 └─ mark-l0-cleared.yml: both present? → adds l0:cleared + comments
+                      └─ export-reward-report.mjs --signups-from-issues reads l0:cleared → credits L0
+```
+
+The tester sees `l0:cleared` (and a 🎉 comment) on their own sign-up issue the moment
+both forms are in. The reward export needs no `--l0` CSV anymore.
+
+## One-time setup
+
+**Prerequisite — both feedback forms must ask for the GitHub username.** Add a short-answer
+question whose title contains the word "GitHub" (e.g. "GitHub username"). The tester enters
+the same username they used to open their sign-up issue. The bridge matches on it.
+
+**GitHub side (already in this repo):**
+- Labels `l0:studio-done` / `l0:pc-done` / `l0:cleared` — apply with `scripts/setup-labels-and-board.sh`.
+- Workflow [`.github/workflows/mark-l0-cleared.yml`](../.github/workflows/mark-l0-cleared.yml) — combines the two into `l0:cleared`.
+
+**Per form** (do this for 0G Studio Feedback AND 0G Private Computer Feedback):
+1. Open the form → **Extensions → Apps Script**.
+2. Paste [`l0-feedback-bridge.gs`](./l0-feedback-bridge.gs).
+3. Set `FORM_LABEL`: `'l0:studio-done'` for Studio Feedback, `'l0:pc-done'` for Private Computer.
+4. **Project Settings → Script properties** → add `GITHUB_TOKEN` = a GitHub token with
+   issue write access (a fine-grained PAT scoped to *Issues: Read and write* on
+   `0gfoundation/0g-testing-hub` is ideal — far less scope than a classic `repo` PAT).
+5. **Triggers** → add trigger → function `onFormSubmit`, source *From form*, type *On form submit*.
+
+## Notes
+
+- The bridge writes **only a label** to the sign-up issue — never the feedback content.
+- If a tester submits feedback but never opened a GitHub sign-up issue, the script logs a
+  warning and skips (nothing to label). They clear L0 once they sign up and the bridge re-runs
+  on their next submit, or you can label the issue by hand.
+- Token rotation: update the `GITHUB_TOKEN` script property on each form.

--- a/automation/README.md
+++ b/automation/README.md
@@ -17,6 +17,26 @@ Tester submits a feedback form
 The tester sees `l0:cleared` (and a 🎉 comment) on their own sign-up issue the moment
 both forms are in. The reward export needs no `--l0` CSV anymore.
 
+## Go-live checklist
+
+Run these in order once the bridge code is on `main` (the `mark-l0-cleared` workflow
+only fires from the default branch). Details for each form step are in **One-time setup** below.
+
+1. **Merge to `main`.** The workflow, labels, and the export's `l0:cleared` reader must be on
+   the default branch.
+2. **Create the labels:** `bash scripts/setup-labels-and-board.sh` (adds `signup`, `needs:fix`,
+   `l0:studio-done`, `l0:pc-done`, `l0:cleared`).
+3. **Mint a token:** a fine-grained PAT scoped to *Issues: Read and write* on
+   `0gfoundation/0g-testing-hub`.
+4. **Add the GitHub-username question** to both feedback forms (title containing "GitHub").
+5. **Wire each form's Apps Script** (paste, set `FORM_LABEL`, add `GITHUB_TOKEN`, add the
+   `onFormSubmit` trigger) — see **One-time setup**.
+6. **Smoke test** with your own account:
+   - Open a sign-up issue (`[signup]: <your-username>` + wallet).
+   - Submit each feedback form, entering that same GitHub username.
+   - Watch the sign-up issue gain `l0:studio-done` → `l0:pc-done` → `l0:cleared` + 🎉 comment.
+   - `node scripts/export-reward-report.mjs --signups-from-issues --format md` shows you at L0 / 10.
+
 ## One-time setup
 
 **Prerequisite — both feedback forms must ask for the GitHub username.** Add a short-answer

--- a/automation/l0-feedback-bridge.gs
+++ b/automation/l0-feedback-bridge.gs
@@ -1,0 +1,86 @@
+/**
+ * 0G Testing Hub — L0 feedback → GitHub bridge (Google Apps Script).
+ *
+ * Attach this to EACH L0 feedback Google Form (0G Studio Feedback and
+ * 0G Private Computer Feedback). On submit it finds the submitter's GitHub
+ * sign-up issue and adds this form's L0 label. The `mark-l0-cleared.yml`
+ * workflow then sets `l0:cleared` once both per-form labels are present.
+ *
+ * SETUP (do this once PER FORM):
+ *   1. The form MUST have a question whose title contains "GitHub" — the tester
+ *      types the same GitHub username they used to open their sign-up issue.
+ *   2. In the form: ⋮ → Script editor (Extensions → Apps Script) → paste this file.
+ *   3. Set FORM_LABEL below:
+ *        - 0G Studio Feedback        → 'l0:studio-done'
+ *        - 0G Private Computer Feedback → 'l0:pc-done'
+ *   4. Project Settings → Script properties → add a property named GITHUB_TOKEN
+ *      whose value is a GitHub token with issue-write access to the repo
+ *      (a fine-grained PAT scoped to Issues: Read and write on this repo is ideal).
+ *   5. Triggers (clock icon) → Add trigger → function onFormSubmit,
+ *      event source "From form", event type "On form submit".
+ *
+ * It never writes the feedback content to GitHub — only a label on the sign-up issue.
+ */
+
+const REPO = '0gfoundation/0g-testing-hub';
+const FORM_LABEL = 'l0:studio-done'; // CHANGE per form: 'l0:studio-done' | 'l0:pc-done'
+
+function onFormSubmit(e) {
+  const username = extractGitHubUsername_(e);
+  if (!username) {
+    console.warn('No GitHub username found in the response — skipping.');
+    return;
+  }
+
+  const issue = findSignupIssue_(username);
+  if (!issue) {
+    console.warn('No signup issue found for @' + username + ' — they may not have signed up on GitHub yet.');
+    return;
+  }
+
+  addLabel_(issue.number, FORM_LABEL);
+  console.log('Labelled signup #' + issue.number + ' (@' + username + ') with ' + FORM_LABEL);
+}
+
+// Read the GitHub username from the answer whose question title mentions "GitHub".
+function extractGitHubUsername_(e) {
+  const items = e.response.getItemResponses();
+  for (let i = 0; i < items.length; i += 1) {
+    if (/github/i.test(items[i].getItem().getTitle())) {
+      return String(items[i].getResponse() || '').trim().replace(/^@/, '');
+    }
+  }
+  return '';
+}
+
+// The earliest open-or-closed signup issue created by this user.
+function findSignupIssue_(username) {
+  const url = 'https://api.github.com/repos/' + REPO + '/issues'
+    + '?labels=signup&state=all&creator=' + encodeURIComponent(username) + '&per_page=1';
+  const arr = JSON.parse(ghFetch_(url, 'get').getContentText());
+  return Array.isArray(arr) && arr.length ? arr[0] : null;
+}
+
+function addLabel_(issueNumber, label) {
+  const url = 'https://api.github.com/repos/' + REPO + '/issues/' + issueNumber + '/labels';
+  ghFetch_(url, 'post', { labels: [label] });
+}
+
+function ghFetch_(url, method, payload) {
+  const token = PropertiesService.getScriptProperties().getProperty('GITHUB_TOKEN');
+  if (!token) throw new Error('Set GITHUB_TOKEN in Script properties (Project Settings).');
+  const opts = {
+    method: method,
+    headers: { Authorization: 'Bearer ' + token, Accept: 'application/vnd.github+json' },
+    muteHttpExceptions: true,
+  };
+  if (payload) {
+    opts.contentType = 'application/json';
+    opts.payload = JSON.stringify(payload);
+  }
+  const res = UrlFetchApp.fetch(url, opts);
+  if (res.getResponseCode() >= 300) {
+    throw new Error('GitHub API ' + res.getResponseCode() + ': ' + res.getContentText());
+  }
+  return res;
+}

--- a/scripts/export-reward-report.mjs
+++ b/scripts/export-reward-report.mjs
@@ -25,8 +25,11 @@ if (args.help) {
 const repo = args.repo || process.env.REPO || '0gfoundation/0g-testing-hub';
 const format = args.format || 'md';
 const issues = await loadIssues(args.issues, repo, args.limit || '1000');
-const { users: signups, duplicates: signupDuplicates } = await loadSignupSource(args, repo);
-const l0Done = args.l0 ? await loadL0(args.l0) : new Set();
+const signupSource = await loadSignupSource(args, repo);
+const { users: signups, duplicates: signupDuplicates } = signupSource;
+// L0 completion: an explicit --l0 export wins; otherwise derive it from `l0:cleared`
+// labels on sign-up issues (set by the Google Forms bridge + mark-l0-cleared workflow).
+const l0Done = args.l0 ? await loadL0(args.l0) : (signupSource.l0Done || new Set());
 const report = buildReport(issues, signups, l0Done);
 const output = render(report, format);
 
@@ -151,7 +154,7 @@ async function loadSignupsFromIssues(file, repoName, limit) {
   } else {
     const raw = execFileSync(
       'gh',
-      ['issue', 'list', '--repo', repoName, '--state', 'all', '--limit', String(limit), '--label', 'signup', '--json', 'number,author,body'],
+      ['issue', 'list', '--repo', repoName, '--state', 'all', '--limit', String(limit), '--label', 'signup', '--json', 'number,author,body,labels'],
       { encoding: 'utf8' },
     );
     signupIssues = JSON.parse(raw);
@@ -159,13 +162,15 @@ async function loadSignupsFromIssues(file, repoName, limit) {
 
   const users = new Map();
   const duplicates = new Set();
+  const l0Done = new Set();
   for (const issue of signupIssues) {
     const normalized = normalizeUser(authorLogin(issue));
     if (!normalized) continue;
     if (users.has(normalized)) duplicates.add(normalized);
     users.set(normalized, { row: issue, wallet: walletFromBody(issue.body) });
+    if (hasLabel(issue, 'l0:cleared')) l0Done.add(normalized);
   }
-  return { users, duplicates: [...duplicates] };
+  return { users, duplicates: [...duplicates], l0Done };
 }
 
 // Pull the wallet out of a sign-up issue body, accepting only a well-formed

--- a/scripts/export-reward-report.mjs
+++ b/scripts/export-reward-report.mjs
@@ -44,7 +44,9 @@ if (args.out) {
 // These go to stderr so they never corrupt CSV/JSON piped from stdout.
 const unmatchedAuthors = report.rows.filter((row) => row.acceptedDeduped > 0 && !row.registered);
 const missingWallet = report.rows.filter((row) => row.registered && !row.wallet && row.issueCredit > 0);
-const problemCount = unmatchedAuthors.length + signupDuplicates.length + missingWallet.length;
+const duplicateWallets = findDuplicateWallets(signups);
+const problemCount =
+  unmatchedAuthors.length + signupDuplicates.length + missingWallet.length + duplicateWallets.length;
 
 if (problemCount) {
   console.error(`\n⚠ reward-export diagnostics (${problemCount} issue${problemCount === 1 ? '' : 's'}):`);
@@ -57,6 +59,10 @@ if (problemCount) {
   }
   if (missingWallet.length) {
     console.error(`  ${missingWallet.length} rewardable user(s) missing a wallet: ${missingWallet.map((r) => r.githubUsername).join(', ')}`);
+  }
+  if (duplicateWallets.length) {
+    console.error(`  ${duplicateWallets.length} wallet(s) shared by multiple sign-ups (possible Sybil — verify before paying):`);
+    for (const dup of duplicateWallets) console.error(`    - ${dup.wallet} ← ${dup.users.join(', ')}`);
   }
   if (args.strict) {
     console.error('\n--strict: exiting non-zero because of the diagnostics above.');
@@ -471,6 +477,21 @@ function hasLabel(issue, name) {
 
 function normalizeUser(value) {
   return String(value || '').trim().replace(/^@/, '').toLowerCase();
+}
+
+// One wallet attached to several sign-up usernames is a Sybil signal (many GitHub
+// accounts farming to one payout address). Surface it so it can't pass silently.
+function findDuplicateWallets(signups) {
+  const byWallet = new Map();
+  for (const [username, signup] of signups.entries()) {
+    const wallet = String(signup.wallet || '').trim().toLowerCase();
+    if (!wallet) continue;
+    if (!byWallet.has(wallet)) byWallet.set(wallet, []);
+    byWallet.get(wallet).push(username);
+  }
+  return [...byWallet.entries()]
+    .filter(([, users]) => users.length > 1)
+    .map(([wallet, users]) => ({ wallet, users: users.sort() }));
 }
 
 function render(report, requestedFormat) {


### PR DESCRIPTION
## What

Builds on the GitHub-native sign-up (PR #3) with L0 verification automation, a Sybil guard, and sign-up form polish.

### L0 verification — fully automated (no more manual export cross-referencing)
- **`automation/l0-feedback-bridge.gs`** — Google Apps Script for each L0 feedback form. On submit it finds the tester's sign-up issue by GitHub username and adds `l0:studio-done` / `l0:pc-done` (a label only — never the feedback content).
- **`.github/workflows/mark-l0-cleared.yml`** — when both per-form labels are present, sets `l0:cleared` and comments the tester. Guarded to fire only on those labels on sign-up issues.
- **`scripts/export-reward-report.mjs`** — `--signups-from-issues` now derives L0 completion from the `l0:cleared` label, so no `--l0` CSV is needed.
- **`.github/labels.yml`** — registers `signup`, `needs:fix`, `l0:studio-done`, `l0:pc-done`, `l0:cleared`.
- **`automation/README.md`** — flow, go-live checklist, and per-form setup.

### Sybil guard
- Reward export flags one wallet shared across multiple sign-up usernames (many GitHub accounts → one payout address) and fails `--strict` on it.

### Sign-up form & docs
- Drop the triage-vs-self-declared note from the sign-up intro; instruct testers to put their GitHub username in the title.
- README/AGENTS spell out the two GitHub issue forms (sign-up vs defect) and that L0 feedback is two external forms.

## Verification
- L0 derivation, Sybil detection, wallet parsing, and the combine-workflow logic exercised with fixtures/simulation. YAML + JSON + drift green. `node --check` clean.

## Post-merge setup (required for L0 automation to go live)
See `automation/README.md` → **Go-live checklist**: create labels, mint a fine-grained PAT, add the GitHub-username question to both forms, wire each form's Apps Script, smoke test.
