### PR TITLE
[codex] Improve tester journey tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect-report.yml
+++ b/.github/ISSUE_TEMPLATE/defect-report.yml
@@ -15,6 +15,14 @@ body:
 
         The fields below mirror the defect template — triage uses them to label, route, de-duplicate, and export rewards, so fill them precisely.
 
+        Minimum useful example:
+        - Product: 0G Hub
+        - Severity: P2 — Major
+        - Repro: 1. Connect wallet on Chain ID 16661. 2. Open Bridge. 3. Refresh before confirmation.
+        - Expected: the bridge state recovers or asks me to reconnect.
+        - Actual: the page shows connected wallet but actions stay disabled until a hard reload.
+        - Evidence: screenshot or short recording.
+
   - type: dropdown
     id: ownership
     attributes:

--- a/.github/ISSUE_TEMPLATE/signup.yml
+++ b/.github/ISSUE_TEMPLATE/signup.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Opening this issue registers you and becomes **your personal tracker**. Your **GitHub account** — whoever opens this issue — is your identity and the join key for every reward, read automatically so there is nothing to type and nothing to mismatch.
 
-        **Title:** add your GitHub username after `[signup]:` — e.g. `[signup]: your-github-username`.
+        After registration, the workflow will normalize the issue title to `[signup]: your-github-username`.
 
         Enter your **0G mainnet EVM wallet** below; it is your payout address. This is a **public** repo, so the address is visible — that is expected. **Never paste a private key or seed phrase** — only the public wallet address.
 

--- a/.github/workflows/confirm-signup.yml
+++ b/.github/workflows/confirm-signup.yml
@@ -51,7 +51,21 @@ jobs:
           fi
 
           if printf '%s' "$WALLET" | grep -Eiq '^0x[0-9a-f]{40}$'; then
-            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "✅ Registered **@$AUTHOR** → \`$WALLET\`. Your GitHub account is your testing identity and rewards pay to this wallet. Climb from L0 — see the [README](../../blob/main/README.md)."
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --title "[signup]: $AUTHOR" >/dev/null
+            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file - <<EOF
+          ✅ **Registered @$AUTHOR** → \`$WALLET\`.
+
+          This signup issue is your tracker. Your GitHub account is your testing identity, and rewards pay to this wallet.
+
+          Next steps:
+
+          1. Submit [0G Studio Feedback](https://forms.gle/ymEdZrdTNs4giEm1A).
+          2. Submit [0G Private Computer Feedback](https://forms.gle/G919xrbRyfVJxPZe8).
+          3. Wait for this issue to show \`l0:cleared\` after both forms land.
+          4. Then climb to L1 by filing an accepted App Suite defect: https://github.com/$REPO/issues/new?template=defect-report.yml&labels=defect,status:filed
+
+          See the ladder in [README.md](../../blob/main/README.md#test-report-reward).
+          EOF
             echo "Confirmed sign-up #$ISSUE_NUMBER (@$AUTHOR -> $WALLET)."
           else
             gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs:fix" >/dev/null

--- a/.github/workflows/mark-l0-cleared.yml
+++ b/.github/workflows/mark-l0-cleared.yml
@@ -34,7 +34,12 @@ jobs:
           has() { case " $LABELS " in *" $1 "*) return 0 ;; *) return 1 ;; esac }
 
           if ! { has "l0:studio-done" && has "l0:pc-done"; }; then
-            echo "Only one feedback label so far — waiting for the other."
+            if has "l0:studio-done"; then
+              gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "L0 progress: **0G Studio Feedback received**. Still needed: [0G Private Computer Feedback](https://forms.gle/G919xrbRyfVJxPZe8)."
+            elif has "l0:pc-done"; then
+              gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "L0 progress: **0G Private Computer Feedback received**. Still needed: [0G Studio Feedback](https://forms.gle/ymEdZrdTNs4giEm1A)."
+            fi
+            echo "Only one feedback label so far — commented with the missing form."
             exit 0
           fi
 
@@ -44,5 +49,16 @@ jobs:
           fi
 
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "l0:cleared" >/dev/null
-          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "🎉 **L0 Recruit cleared** — both feedback forms received. That's **10 0G Compute Credit**. Climb to L1 by filing an accepted **App Suite** bug — see the [README](../../blob/main/README.md)."
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file - <<EOF
+          🎉 **L0 Recruit cleared** — both feedback forms received. That's **10 0G Compute Credit**.
+
+          Next: climb to **L1 Tester** with one accepted **App Suite** defect.
+
+          Start here:
+
+          - App Suite targets: [0G App, Genome, 0G Chat, PandaClaw](../../blob/main/README.md#0g-app-suite--core-l0-l1)
+          - Defect report form: https://github.com/$REPO/issues/new?template=defect-report.yml&labels=defect,status:filed
+
+          Acceptance bar: a defect counts only if it is reproducible from your steps, a divergence from documented or expected behavior, and measured against the current stack baseline.
+          EOF
           echo "Marked #$ISSUE_NUMBER l0:cleared."

--- a/.github/workflows/notify-status-change.yml
+++ b/.github/workflows/notify-status-change.yml
@@ -28,7 +28,10 @@ jobs:
       REPO: ${{ github.repository }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}
       LABEL: ${{ github.event.label.name }}
+      AUTHOR: ${{ github.event.issue.user.login }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Comment on the issue
         run: |
           set -euo pipefail
@@ -63,3 +66,100 @@ jobs:
 
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$MSG"
           echo "Commented on #$ISSUE_NUMBER for $LABEL."
+
+      - name: Update signup progress preview
+        if: >-
+          github.event.label.name == 'status:accepted' ||
+          github.event.label.name == 'status:routed'
+        run: |
+          set -euo pipefail
+
+          LABELS=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name' | tr '\n' ' ')
+          has() { case " $LABELS " in *" $1 "*) return 0 ;; *) return 1 ;; esac }
+
+          if has "area:ecosystem" || has "coverage-log"; then
+            echo "Ecosystem coverage is record-only; skipping reward progress preview."
+            exit 0
+          fi
+
+          if ! { has "area:app-suite" || has "area:0g-infra"; }; then
+            echo "No rewardable core area label; skipping reward progress preview."
+            exit 0
+          fi
+
+          SIGNUP_NUMBER=$(gh issue list \
+            --repo "$REPO" \
+            --state all \
+            --label signup \
+            --author "$AUTHOR" \
+            --limit 100 \
+            --json number,createdAt \
+            --jq 'sort_by(.createdAt)[0].number // ""')
+
+          if [ -z "$SIGNUP_NUMBER" ]; then
+            echo "No signup issue found for @$AUTHOR; skipping reward progress preview."
+            exit 0
+          fi
+
+          REPORT=$(node scripts/export-reward-report.mjs --repo "$REPO" --signups-from-issues --format json)
+          USER=$(printf '%s' "$AUTHOR" | tr '[:upper:]' '[:lower:]')
+          ROW=$(jq -c --arg user "$USER" '.rows[] | select(.githubUsername == $user)' <<<"$REPORT" | head -n 1)
+
+          if [ -z "$ROW" ]; then
+            echo "No reward row found for @$AUTHOR; skipping reward progress preview."
+            exit 0
+          fi
+
+          LEVEL=$(jq -r '.issueLevel // ""' <<<"$ROW")
+          CREDIT=$(jq -r '.issueCredit // 0' <<<"$ROW")
+          TOTAL=$(jq -r '.acceptedDeduped // 0' <<<"$ROW")
+          APP_SUITE=$(jq -r '.appSuite // 0' <<<"$ROW")
+          INFRA=$(jq -r '.infra // 0' <<<"$ROW")
+          SYSTEMIC=$(jq -r '.systemic // 0' <<<"$ROW")
+          CANONICAL=$(jq -r '.canonicalIssues // ""' <<<"$ROW")
+
+          if [ -z "$LEVEL" ]; then
+            LEVEL="not yet"
+          fi
+
+          if [ "$LEVEL" = "L3" ]; then
+            NEXT="L3 is the current cap. Keep reports high-signal; final payout still follows export."
+          elif [ "$APP_SUITE" -lt 1 ]; then
+            NEXT="Need 1 accepted App Suite defect for L1."
+          elif [ "$INFRA" -lt 1 ]; then
+            NEXT="Need 1 accepted 0G Infra defect, paired with your App Suite accept, for L2."
+          else
+            NEED_CORE=$((5 - TOTAL))
+            if [ "$NEED_CORE" -lt 0 ]; then
+              NEED_CORE=0
+            fi
+
+            if [ "$NEED_CORE" -gt 0 ] && [ "$SYSTEMIC" -lt 1 ]; then
+              NEXT="Need ${NEED_CORE} more accepted, deduped core defect(s) and 1 systemic finding for L3."
+            elif [ "$NEED_CORE" -gt 0 ]; then
+              NEXT="Need ${NEED_CORE} more accepted, deduped core defect(s) for L3."
+            elif [ "$SYSTEMIC" -lt 1 ]; then
+              NEXT="Need 1 systemic finding for L3."
+            else
+              NEXT="L3 criteria appear met; final payout still follows export."
+            fi
+          fi
+
+          gh issue comment "$SIGNUP_NUMBER" --repo "$REPO" --body-file - <<EOF
+          📊 **Reward progress preview** (advisory)
+
+          Current level: **$LEVEL** ($CREDIT 0G Compute Credit)
+
+          Accepted, deduped core findings: **$TOTAL**
+          - App Suite: **$APP_SUITE**
+          - 0G Infra: **$INFRA**
+          - Systemic: **$SYSTEMIC**
+
+          Canonical issues: ${CANONICAL:-none yet}
+
+          Next gate: $NEXT
+
+          Final payout still comes from the reward export after triage and de-duplication.
+          EOF
+
+          echo "Updated signup #$SIGNUP_NUMBER with reward progress preview for @$AUTHOR."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ All rewards are **0G Compute Credit**; payout = the Credit of the **highest leve
 
 Track filed issues on the [Defect board #19](https://github.com/orgs/0gfoundation/projects/19). The more **accepted, deduped** defects a tester surfaces, the higher they climb - Master is the cap. Ecosystem dApps are **record-only**: log coverage, not a reward gate.
 
-Two GitHub issue forms drive the program: **`signup.yml`** (label `signup` — step 0, identity + wallet, handled by `confirm-signup.yml`) and **`defect-report.yml`** (labels `defect` + `status:filed` — steps 2–4, one bug/coverage log per issue, handled by `add-defects-to-board.yml` + `notify-status-change.yml`). Step 1's L0 feedback is two external Google forms (see `config.yml` contact links), not GitHub issues.
+Two GitHub issue forms drive the program: **`signup.yml`** (label `signup` — step 0, identity + wallet + personal tracker, handled by `confirm-signup.yml`) and **`defect-report.yml`** (labels `defect` + `status:filed` — steps 2–4, one bug/coverage log per issue, handled by `add-defects-to-board.yml` + `notify-status-change.yml`). Step 1's L0 feedback is two external Google forms (see `config.yml` contact links), not GitHub issues.
 
 ```json
 {
@@ -41,13 +41,13 @@ Two GitHub issue forms drive the program: **`signup.yml`** (label `signup` — s
 
 The reward system depends on this chain. Do not bypass it:
 
-1. **Sign-up issue** (`signup.yml`, labelled `signup`) registers the tester. The **issue author** is the authenticated **GitHub username** — the identity join key, captured automatically so it can't be mistyped — and the **0G mainnet EVM wallet** is recorded in the issue body (public). `confirm-signup.yml` validates the wallet and confirms registration. Reward export reads these via `--signups-from-issues`, so no external signup form is needed.
-2. **L0 feedback bridge** — the two external Google feedback forms each run an Apps Script (`automation/l0-feedback-bridge.gs`) that labels the tester's sign-up issue `l0:studio-done` / `l0:pc-done` by GitHub username; `mark-l0-cleared.yml` sets `l0:cleared` once both arrive. See [`automation/README.md`](./automation/README.md).
+1. **Sign-up issue** (`signup.yml`, labelled `signup`) registers the tester. The **issue author** is the authenticated **GitHub username** — the identity join key, captured automatically so it can't be mistyped — and the **0G mainnet EVM wallet** is recorded in the issue body (public). `confirm-signup.yml` validates the wallet, normalizes the title to `[signup]: <author>`, and comments the L0 next steps. Reward export reads these signup issues via `--signups-from-issues`, so no external signup form is needed.
+2. **L0 feedback bridge** — the two external Google feedback forms each run an Apps Script (`automation/l0-feedback-bridge.gs`) that labels the tester's sign-up issue `l0:studio-done` / `l0:pc-done` by GitHub username; `mark-l0-cleared.yml` comments partial progress when only one form has arrived, then sets `l0:cleared` and points the tester toward L1 once both arrive. See [`automation/README.md`](./automation/README.md).
 3. **Defect report / coverage log form** creates GitHub issues labelled `defect` + `status:filed`.
 4. **Workflow** adds every `defect` issue to Project #19, derives `area:*` / `sev:*` / `coverage-log` labels from the form body, and keeps the board's Triage state aligned with `status:filed`. If the form body can't be parsed, it applies `needs:manual-label` so the gap is visible instead of silently shipping unlabelled.
 5. **Triage** moves issues through `status:accepted` and `status:routed`, applies one `area:*`, one `sev:*`, optional `rc:*`, and `systemic` when appropriate.
 6. **Route evidence** is required before `status:routed`: add a comment containing `Routed to:` and `Upstream link:`. Look up the upstream owner in [`data/owners.json`](./data/owners.json) so routing doesn't depend on tribal knowledge.
-7. **Reward export** runs `node scripts/export-reward-report.mjs --signups-from-issues --format csv --out rewards.csv` — it reads the `signup` issues directly (author = GitHub username, body = wallet), counts accepted + deduped App Suite / 0G Infra defects, and credits L0 from the `l0:cleared` label. `--strict` blocks payout on unmatched issue authors, duplicate signup usernames, **duplicate wallets (Sybil)**, or rewardable users missing a wallet. (A legacy `--signups <csv>` / `--l0 <csv>` path remains for non-GitHub data.)
+7. **Reward preview + export** — `notify-status-change.yml` comments an advisory reward progress preview on the tester's signup issue when rewardable core defects reach `status:accepted` / `status:routed`; final payout still comes from `node scripts/export-reward-report.mjs --signups-from-issues --format csv --out rewards.csv`. The export reads `signup` issues directly (author = GitHub username, body = wallet), counts accepted + deduped App Suite / 0G Infra defects, and credits L0 from the `l0:cleared` label. `--strict` blocks payout on unmatched issue authors, duplicate signup usernames, **duplicate wallets (Sybil)**, or rewardable users missing a wallet. (A legacy `--signups <csv>` / `--l0 <csv>` path remains for non-GitHub data.)
 
 Routed evidence check:
 
@@ -67,7 +67,7 @@ node scripts/check-routed-evidence.mjs --repo 0gfoundation/0g-testing-hub
 
 ## Test Targets
 
-`data/targets.json` is the source of truth for target URLs and descriptions. Do not hand-edit README's generated target block. Edit `data/targets.json`, then run:
+`data/targets.json` is the source of truth for target URLs, descriptions, and per-target checklists. Do not hand-edit README's generated target block. Edit `data/targets.json`, then run:
 
 ```bash
 node scripts/render-targets-readme.mjs --write

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ All rewards are **0G Compute Credit**; payout = the Credit of your **highest lev
 | **3** | **L2** Infra Pioneer | +1 accepted · 0G Infra (2 total) | [Defect report form](https://github.com/0gfoundation/0g-testing-hub/issues/new?template=defect-report.yml&labels=defect,status:filed) | **40 0G Compute Credit** |
 | **4** | **L3** Master | 5+ accepted · incl. 1 `systemic` | [Defect report form](https://github.com/0gfoundation/0g-testing-hub/issues/new?template=defect-report.yml&labels=defect,status:filed) | **100 0G Compute Credit** |
 
-Track your filed issues on the [Defect board #19](https://github.com/orgs/0gfoundation/projects/19). The more **accepted, deduped** defects you surface, the higher you climb - Master is the cap.
+Track filed defects on the [Defect board #19](https://github.com/orgs/0gfoundation/projects/19). Track your personal journey on your **sign-up issue**: the workflow normalizes its title, comments L0 feedback progress, and posts an advisory reward progress preview after accepted / routed core defects. Final reward decisions still come from triage and the reward export.
 
-Two GitHub issue forms drive this: **[Sign up](https://github.com/0gfoundation/0g-testing-hub/issues/new?template=signup.yml&labels=signup)** (step 0 — identity + wallet) and **[Defect report](https://github.com/0gfoundation/0g-testing-hub/issues/new?template=defect-report.yml&labels=defect,status:filed)** (steps 2–4 — one bug or coverage log per issue). Step 1's L0 feedback is the two external Google forms above.
+Two GitHub issue forms drive this: **[Sign up](https://github.com/0gfoundation/0g-testing-hub/issues/new?template=signup.yml&labels=signup)** (step 0 — identity + wallet + personal tracker) and **[Defect report](https://github.com/0gfoundation/0g-testing-hub/issues/new?template=defect-report.yml&labels=defect,status:filed)** (steps 2–4 — one bug or coverage log per issue). Step 1's L0 feedback is the two external Google forms above.
 
 **Won't be accepted / out of bounds:**
 
@@ -44,28 +44,113 @@ Two GitHub issue forms drive this: **[Sign up](https://github.com/0gfoundation/0
 ### 0G App Suite · core (L0-L1)
 
 - [**0G App**](https://app.0g.ai/) - flagship app builder, live on mainnet
+  - Checklist:
+    - Load the app.
+    - Connect a wallet on 0G.
+    - Walk the core journey once.
+    - Try one interrupt or error path: stale session, captcha/token expiry, Chain ID switch, refresh, or back button.
 - [**Genome**](https://dev.0g-vibe.pages.dev/genome) - paste a URL/screenshot, produces production-grade design DNA
+  - Checklist:
+    - Load the app.
+    - Connect a wallet on 0G.
+    - Walk the core journey once.
+    - Try one interrupt or error path: stale session, captcha/token expiry, Chain ID switch, refresh, or back button.
 - [**0G Chat**](https://dev.0g-vibe.pages.dev/private-chat) - end-to-end encrypted private chat (UI still WIP)
+  - Checklist:
+    - Load the app.
+    - Connect a wallet on 0G.
+    - Walk the core journey once.
+    - Try one interrupt or error path: stale session, captcha/token expiry, Chain ID switch, refresh, or back button.
 - [**PandaClaw**](https://dev.0g-vibe.pages.dev/agents) - agent launchpad + skill marketplace (Hermes + OpenClaw harness)
+  - Checklist:
+    - Load the app.
+    - Connect a wallet on 0G.
+    - Walk the core journey once.
+    - Try one interrupt or error path: stale session, captcha/token expiry, Chain ID switch, refresh, or back button.
 
 ### 0G Infra · core (L2)
 
 - [**0G Hub**](https://hub.0g.ai/) - bridge / swap / faucet / portfolio
+  - Checklist:
+    - Load or initialize the target.
+    - Check correctness over polish: Chain ID, RPC, explorer data, or storage/inference path.
+    - Walk one core flow; for bridge, swap, faucet, or sign flows, stop at confirmation.
+    - Try one error path.
 - [**0G Storage Scan**](https://storagescan-newton.0g.ai/) - storage explorer
+  - Checklist:
+    - Load or initialize the target.
+    - Check correctness over polish: Chain ID, RPC, explorer data, or storage/inference path.
+    - Walk one core flow; for bridge, swap, faucet, or sign flows, stop at confirmation.
+    - Try one error path.
 - [**Chain Scan**](https://chainscan.0g.ai/) - block explorer
+  - Checklist:
+    - Load or initialize the target.
+    - Check correctness over polish: Chain ID, RPC, explorer data, or storage/inference path.
+    - Walk one core flow; for bridge, swap, faucet, or sign flows, stop at confirmation.
+    - Try one error path.
 - [**0G Code to Coin (0g-cc)**](https://www.npmjs.com/package/@0gfoundation/0g-cc) - MCP server for AI inference / storage on 0G Compute
   - Note: `0g-cc` is a CLI / MCP server, not a web app. Add it (`claude mcp add 0g-cc npx @0gfoundation/0g-cc`), then walk one inference / storage flow plus one error path. The funds/keys boundary still applies.
+  - Checklist:
+    - Add the MCP server with `claude mcp add 0g-cc npx @0gfoundation/0g-cc`.
+    - Walk one inference or storage flow.
+    - Trigger one config, auth, or invalid-input error path.
+    - Do not expose funds, keys, or private data.
 
 ### 0G Ecosystem dApp
 
 - [**TradeGPT**](https://tradegpt.finance/) - AI-driven DEX
+  - Checklist:
+    - Load the dApp.
+    - Connect a wallet on 0G if supported.
+    - Walk the main flow once.
+    - Report actionable bugs to the dApp's own channel and paste that URL in the Hub coverage log.
 - [**Jaine**](https://jaine.fi/) - DEX/liquidity (LIC)
+  - Checklist:
+    - Load the dApp.
+    - Connect a wallet on 0G if supported.
+    - Walk the main flow once.
+    - Report actionable bugs to the dApp's own channel and paste that URL in the Hub coverage log.
 - [**Oku**](https://oku.trade/) - concentrated liquidity DEX
+  - Checklist:
+    - Load the dApp.
+    - Connect a wallet on 0G if supported.
+    - Walk the main flow once.
+    - Report actionable bugs to the dApp's own channel and paste that URL in the Hub coverage log.
 - [**AI Arena**](https://aiarena.io/) - PvP, train AI agents
+  - Checklist:
+    - Load the dApp.
+    - Connect a wallet on 0G if supported.
+    - Walk the main flow once.
+    - Report actionable bugs to the dApp's own channel and paste that URL in the Hub coverage log.
 - [**CARV**](https://carv.io/) - gamer identity
+  - Checklist:
+    - Load the dApp.
+    - Connect a wallet on 0G if supported.
+    - Walk the main flow once.
+    - Report actionable bugs to the dApp's own channel and paste that URL in the Hub coverage log.
 - [**Cygnus Finance**](https://cygnus.finance/) - RWA stablecoin
+  - Checklist:
+    - Load the dApp.
+    - Connect a wallet on 0G if supported.
+    - Walk the main flow once.
+    - Report actionable bugs to the dApp's own channel and paste that URL in the Hub coverage log.
 - [**DataHive**](https://datahive.network/) - personal data economy
+  - Checklist:
+    - Load the dApp.
+    - Connect a wallet on 0G if supported.
+    - Walk the main flow once.
+    - Report actionable bugs to the dApp's own channel and paste that URL in the Hub coverage log.
 - [**Khalani**](https://hub.0g.ai/khalani/transfer?network=mainnet) - bridge to 0G
+  - Checklist:
+    - Load the dApp.
+    - Connect a wallet on 0G if supported.
+    - Walk the main flow once.
+    - Report actionable bugs to the dApp's own channel and paste that URL in the Hub coverage log.
 - [**Merkl**](https://app.merkl.xyz/) - claim LIC rewards
+  - Checklist:
+    - Load the dApp.
+    - Connect a wallet on 0G if supported.
+    - Walk the main flow once.
+    - Report actionable bugs to the dApp's own channel and paste that URL in the Hub coverage log.
 
 <!-- targets:end -->

--- a/data/targets.json
+++ b/data/targets.json
@@ -10,6 +10,12 @@
       "pillKind": "app",
       "recordOnly": false,
       "notice": "L0 Recruit is feedback-only: 0G Studio Feedback + 0G Private Computer Feedback, no bug required. From L1 upward, submit reproducible bugs through the GitHub defect form.",
+      "checklist": [
+        "Load the app.",
+        "Connect a wallet on 0G.",
+        "Walk the core journey once.",
+        "Try one interrupt or error path: stale session, captcha/token expiry, Chain ID switch, refresh, or back button."
+      ],
       "forms": [
         {
           "label": "Report a bug",
@@ -47,6 +53,12 @@
       "pill": "0G Infra · escalate",
       "pillKind": "infra",
       "recordOnly": false,
+      "checklist": [
+        "Load or initialize the target.",
+        "Check correctness over polish: Chain ID, RPC, explorer data, or storage/inference path.",
+        "Walk one core flow; for bridge, swap, faucet, or sign flows, stop at confirmation.",
+        "Try one error path."
+      ],
       "items": [
         {
           "name": "0G Hub",
@@ -67,7 +79,13 @@
           "name": "0G Code to Coin (0g-cc)",
           "desc": "MCP server for AI inference / storage on 0G Compute",
           "url": "https://www.npmjs.com/package/@0gfoundation/0g-cc",
-          "note": "`0g-cc` is a CLI / MCP server, not a web app. Add it (`claude mcp add 0g-cc npx @0gfoundation/0g-cc`), then walk one inference / storage flow plus one error path. The funds/keys boundary still applies."
+          "note": "`0g-cc` is a CLI / MCP server, not a web app. Add it (`claude mcp add 0g-cc npx @0gfoundation/0g-cc`), then walk one inference / storage flow plus one error path. The funds/keys boundary still applies.",
+          "checklist": [
+            "Add the MCP server with `claude mcp add 0g-cc npx @0gfoundation/0g-cc`.",
+            "Walk one inference or storage flow.",
+            "Trigger one config, auth, or invalid-input error path.",
+            "Do not expose funds, keys, or private data."
+          ]
         }
       ]
     },
@@ -79,6 +97,12 @@
       "pill": "record-only",
       "pillKind": "record",
       "recordOnly": true,
+      "checklist": [
+        "Load the dApp.",
+        "Connect a wallet on 0G if supported.",
+        "Walk the main flow once.",
+        "Report actionable bugs to the dApp's own channel and paste that URL in the Hub coverage log."
+      ],
       "items": [
         {
           "name": "TradeGPT",

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -5,7 +5,7 @@ layer between them. This is the visual companion to [`.github/TRIAGE.md`](../.gi
 (the maintainer runbook) and [`LEVELS.md`](../LEVELS.md) (the reward ladder).
 
 - **Tester** only ever fills forms — never touches labels, the board, or `defects/*.md`.
-- **Automation** (GitHub Actions) labels, boards, and closes the feedback loop.
+- **Automation** (GitHub Actions) labels, boards, updates the signup tracker, and closes the feedback loop.
 - **Maintainer** runs the label → verify → dedup → route → export pipeline.
 
 ## End-to-end flow
@@ -13,13 +13,14 @@ layer between them. This is the visual companion to [`.github/TRIAGE.md`](../.gi
 ```mermaid
 flowchart TD
     subgraph T["🧑‍💻 Tester — fills forms only"]
-      T1["Sign up once<br/>wallet + GitHub username"]
+      T1["Sign up once<br/>wallet; GitHub author = identity"]
       T2["L0: two feedback forms<br/>no bug required"]
       T3["Find + reproduce a bug"]
       T4["File Defect report form<br/>one issue per defect"]
     end
 
     subgraph A["⚙️ Automation — GitHub Actions"]
+      A0["signup issue tracker<br/>auto-title · L0 progress · reward preview"]
       A1["Issue opened<br/>defect + status:filed"]
       A2["add-defects-to-board.yml<br/>add to board #19 · parse area/sev · set Triage"]
       A3["notify-status-change.yml<br/>auto-comment outcome to the tester"]
@@ -35,14 +36,15 @@ flowchart TD
       M7["export-reward-report.mjs<br/>join username → wallet · tally L0–L3"]
     end
 
-    T1 --> T2 --> T3 --> T4 --> A1 --> A2 --> M1 --> M2
+    T1 --> A0 --> T2 --> T3 --> T4 --> A1 --> A2 --> M1 --> M2
     M2 -- yes --> M3 --> M5 --> M6 --> M7
     M2 -- no --> M4
     M3 -. triggers .-> A3
     M4 -. triggers .-> A3
     M6 -. triggers .-> A3
     A3 -. result comment .-> T4
-    T1 -. "GitHub username = join key" .-> M7
+    A3 -. reward preview .-> A0
+    A0 -. "issue author = join key" .-> M7
 ```
 
 ## Status state machine → board columns
@@ -83,5 +85,9 @@ and pass conditions are the evergreen spec in [`LEVELS.md`](../LEVELS.md), mirro
   message: App Suite accept counts; an **0G Infra** accept alone does **not** clear L1
   (needs a paired App Suite bug → L2); an **Ecosystem** coverage log is record-only and
   does **not** count.
+- **The signup issue is the tester's tracker.** Signup confirmation normalizes the title
+  from the issue author, L0 feedback automation comments partial / cleared states, and
+  accepted or routed core defects add an advisory reward progress preview. Final payout
+  still comes from `export-reward-report.mjs`.
 
 Open items that are policy/data decisions, not code: see [`KNOWN-GAPS.md`](../KNOWN-GAPS.md).

--- a/scripts/render-targets-readme.mjs
+++ b/scripts/render-targets-readme.mjs
@@ -52,9 +52,10 @@ export async function renderTargets() {
     for (const item of bucket.items || []) {
       lines.push(`- [**${item.name}**](${item.url})${item.desc ? ` - ${item.desc}` : ''}`);
       if (item.note) lines.push(`  - Note: ${item.note}`);
-      if (Array.isArray(item.checklist) && item.checklist.length) {
+      const checklist = Array.isArray(item.checklist) ? item.checklist : bucket.checklist;
+      if (Array.isArray(checklist) && checklist.length) {
         lines.push('  - Checklist:');
-        for (const check of item.checklist) lines.push(`    - ${check}`);
+        for (const check of checklist) lines.push(`    - ${check}`);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Turn the signup issue into the tester's personal tracker: auto-normalized title, clearer registration checklist, partial L0 feedback comments, and L0-cleared guidance toward L1.
- Improve defect filing quality with a minimal useful defect example in the issue form.
- Add generated per-target checklists from `data/targets.json`, rendered into the README target wall.
- Add advisory reward progress previews on signup issues after rewardable core defects reach `status:accepted` / `status:routed`.
- Align `README.md`, `AGENTS.md`, and `docs/WORKFLOWS.md` with the new tester journey and source-of-truth rules.

## Why

The previous flow worked, but testers still had to infer too much from README text, labels, and board state. This change makes the path from signup → L0 → first accepted bug → reward progress visible on the tester's own signup issue, while preserving reward export as the final payout source.

## Notes

- Reward progress preview is advisory only; final payout still comes from `scripts/export-reward-report.mjs` after triage and de-duplication.
- README target checklists are generated from `data/targets.json`; README's generated target block should not be hand-edited.

## Validation

- YAML parse check for modified issue forms / workflows
- `bash -n` for embedded workflow shell scripts
- `node --check scripts/render-targets-readme.mjs`
- `node scripts/check-targets-drift.mjs`
- `git diff --check`
