### PR TITLE
feat(scripts): extend check-targets-drift to a 4-way consistency check

### DIFF
--- a/.github/workflows/check-drift.yml
+++ b/.github/workflows/check-drift.yml
@@ -1,22 +1,37 @@
 name: Check targets drift
 
-# data/targets.json is the single source of truth for the site's test-target
-# wall. This guards it against drifting from README.md → Test targets. Runs only
-# when either side changes; pure read-only check, never writes back.
+# data/targets.json is the single source of truth for every surface that lists
+# or maps products. This guards five edges against drift: the README targets
+# block, the Submit Feedback Product dropdown, the Product → area / product:*
+# maps in add-defects-to-board.yml and setup-labels-and-board.sh, and
+# data/owners.json + the product:* labels in labels.yml. Runs when any side
+# changes; pure read-only check, never writes back.
 
 on:
   push:
     paths:
       - data/targets.json
+      - data/owners.json
       - README.md
+      - .github/ISSUE_TEMPLATE/submit-feedback.yml
+      - .github/workflows/add-defects-to-board.yml
+      - .github/workflows/check-drift.yml
+      - .github/labels.yml
       - scripts/check-targets-drift.mjs
       - scripts/render-targets-readme.mjs
+      - scripts/setup-labels-and-board.sh
   pull_request:
     paths:
       - data/targets.json
+      - data/owners.json
       - README.md
+      - .github/ISSUE_TEMPLATE/submit-feedback.yml
+      - .github/workflows/add-defects-to-board.yml
+      - .github/workflows/check-drift.yml
+      - .github/labels.yml
       - scripts/check-targets-drift.mjs
       - scripts/render-targets-readme.mjs
+      - scripts/setup-labels-and-board.sh
 
 jobs:
   check:

--- a/data/targets.json
+++ b/data/targets.json
@@ -1,5 +1,5 @@
 {
-  "note": "Single source of truth for README -> Test targets. Edit here, then run `node scripts/render-targets-readme.mjs --write`.",
+  "note": "Single source of truth for README -> Test targets. Edit here, then run `node scripts/render-targets-readme.mjs --write`. Each item's productLabel drives the product:* label; legacyAliases lists retired names still parsed from old issue bodies.",
   "intro": "Test the core user flow for each target, including one happy path and one error path. File reproducible DX friction: confusing setup, unclear errors, broken docs, wallet/network issues, blocked flows, or behavior that diverges from what the product promises.",
   "buckets": [
     {
@@ -21,22 +21,29 @@
         {
           "name": "0G App",
           "desc": "flagship app builder, live on mainnet",
-          "url": "https://app.0g.ai/"
+          "url": "https://app.0g.ai/",
+          "productLabel": "0g-app"
         },
         {
           "name": "Genome",
           "desc": "paste a URL/screenshot, produces production-grade design DNA",
-          "url": "https://app.0g.ai/genome"
+          "url": "https://app.0g.ai/genome",
+          "productLabel": "genome"
         },
         {
           "name": "0G Chat",
           "desc": "end-to-end encrypted private chat (UI still WIP)",
-          "url": "https://app.0g.ai/private-chat"
+          "url": "https://app.0g.ai/private-chat",
+          "productLabel": "0g-chat"
         },
         {
           "name": "Agent launchpad",
           "desc": "agent launchpad + skill marketplace (Hermes + OpenClaw harness)",
-          "url": "https://app.0g.ai/agent-launchpad"
+          "url": "https://app.0g.ai/agent-launchpad",
+          "productLabel": "agent-launchpad",
+          "legacyAliases": [
+            "PandaClaw"
+          ]
         }
       ]
     },
@@ -52,23 +59,27 @@
         {
           "name": "0G Hub",
           "desc": "bridge / swap / faucet / portfolio",
-          "url": "https://hub.0g.ai/"
+          "url": "https://hub.0g.ai/",
+          "productLabel": "0g-hub"
         },
         {
           "name": "0G Storage Scan",
           "desc": "storage explorer",
-          "url": "https://storagescan-newton.0g.ai/"
+          "url": "https://storagescan-newton.0g.ai/",
+          "productLabel": "storage-scan"
         },
         {
           "name": "Chain Scan",
           "desc": "block explorer",
-          "url": "https://chainscan.0g.ai/"
+          "url": "https://chainscan.0g.ai/",
+          "productLabel": "chain-scan"
         },
         {
           "name": "0G Code to Coin (0g-cc)",
           "desc": "MCP server for AI inference / storage on 0G Compute",
           "url": "https://www.npmjs.com/package/@0gfoundation/0g-cc",
-          "note": "`0g-cc` is a CLI / MCP server, not a web app. Add it (`claude mcp add 0g-cc npx @0gfoundation/0g-cc`), then walk one inference / storage flow plus one error path. The funds/keys boundary still applies."
+          "note": "`0g-cc` is a CLI / MCP server, not a web app. Add it (`claude mcp add 0g-cc npx @0gfoundation/0g-cc`), then walk one inference / storage flow plus one error path. The funds/keys boundary still applies.",
+          "productLabel": "0g-cc"
         }
       ]
     },
@@ -84,47 +95,56 @@
         {
           "name": "TradeGPT",
           "desc": "AI-driven DEX",
-          "url": "https://tradegpt.finance/"
+          "url": "https://tradegpt.finance/",
+          "productLabel": "tradegpt"
         },
         {
           "name": "Jaine",
           "desc": "DEX/liquidity (LIC)",
-          "url": "https://jaine.fi/"
+          "url": "https://jaine.fi/",
+          "productLabel": "jaine"
         },
         {
           "name": "Oku",
           "desc": "concentrated liquidity DEX",
-          "url": "https://oku.trade/"
+          "url": "https://oku.trade/",
+          "productLabel": "oku"
         },
         {
           "name": "AI Arena",
           "desc": "PvP, train AI agents",
-          "url": "https://aiarena.io/"
+          "url": "https://aiarena.io/",
+          "productLabel": "ai-arena"
         },
         {
           "name": "CARV",
           "desc": "gamer identity",
-          "url": "https://carv.io/"
+          "url": "https://carv.io/",
+          "productLabel": "carv"
         },
         {
           "name": "Cygnus Finance",
           "desc": "RWA stablecoin",
-          "url": "https://cygnus.finance/"
+          "url": "https://cygnus.finance/",
+          "productLabel": "cygnus"
         },
         {
           "name": "DataHive",
           "desc": "personal data economy",
-          "url": "https://datahive.network/"
+          "url": "https://datahive.network/",
+          "productLabel": "datahive"
         },
         {
           "name": "Khalani",
           "desc": "bridge to 0G",
-          "url": "https://hub.0g.ai/khalani/transfer?network=mainnet"
+          "url": "https://hub.0g.ai/khalani/transfer?network=mainnet",
+          "productLabel": "khalani"
         },
         {
           "name": "Merkl",
           "desc": "claim LIC rewards",
-          "url": "https://app.merkl.xyz/"
+          "url": "https://app.merkl.xyz/",
+          "productLabel": "merkl"
         }
       ]
     }

--- a/scripts/check-targets-drift.mjs
+++ b/scripts/check-targets-drift.mjs
@@ -1,12 +1,24 @@
 #!/usr/bin/env node
 /*
- * Drift sentinel: data/targets.json is the single source of truth for
- * README.md -> Test targets. This compares the generated markdown block against
- * the checked-in README block, not just URLs.
+ * Drift sentinel: data/targets.json is the single source of truth for every
+ * surface that lists or maps products. This checks five edges against it:
+ *
+ *   1. README.md -> Test targets generated block
+ *   2. .github/ISSUE_TEMPLATE/submit-feedback.yml -> Product dropdown options
+ *   3. .github/workflows/add-defects-to-board.yml -> Product -> area / product:* map
+ *   4. scripts/setup-labels-and-board.sh          -> the same map (lockstep copy)
+ *   5. data/owners.json + .github/labels.yml      -> owner entries / product:* labels
+ *
+ * Per-item `productLabel` names the product:* label; `legacyAliases` lists
+ * retired product names that the body-parsing maps must still route (old issue
+ * bodies), but that must NOT appear in the dropdown, owners, or labels.
+ *
+ * Any source that yields zero parsed entries is a hard failure — a format
+ * change must break the check loudly, never silently skip it.
  *
  * Usage:
  *   node scripts/check-targets-drift.mjs
- *   node scripts/render-targets-readme.mjs --write
+ *   node scripts/render-targets-readme.mjs --write   (to fix edge 1)
  */
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -14,25 +26,238 @@ import { dirname, join } from 'node:path';
 import { END, START, renderTargets } from './render-targets-readme.mjs';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
-const README = join(root, 'README.md');
+const FILES = {
+  targets: 'data/targets.json',
+  readme: 'README.md',
+  form: '.github/ISSUE_TEMPLATE/submit-feedback.yml',
+  workflow: '.github/workflows/add-defects-to-board.yml',
+  setup: 'scripts/setup-labels-and-board.sh',
+  owners: 'data/owners.json',
+  labels: '.github/labels.yml',
+};
 
-const readme = await readFile(README, 'utf8');
-const current = extractBlock(readme).trim();
-const expected = (await renderTargets()).trim();
+// Case-arm patterns that are flow structure, not products: the Other gates and
+// the legacy Ownership-dropdown fallback. Everything else in a map must trace
+// back to a product name or a registered legacy alias.
+const STRUCTURAL_PATTERNS = new Set([
+  'Other',
+  'Other Ecosystem dApp',
+  'App Suite',
+  '0G Infra',
+  'Ecosystem dApp',
+]);
 
-if (current !== expected) {
-  console.error('✖ README.md -> Test targets has drifted from data/targets.json.');
-  console.error('Fix: run `node scripts/render-targets-readme.mjs --write` and commit the result.');
-  process.exit(1);
+const AREA_BY_BUCKET = { app: 'area:app-suite', infra: 'area:0g-infra', eco: 'area:ecosystem' };
+
+const failures = [];
+const summaries = [];
+const fail = (file, subject, msg) => failures.push(`✖ ${file} :: ${subject} :: ${msg}`);
+
+// ---- Source of truth -------------------------------------------------------
+
+const data = JSON.parse(await read(FILES.targets));
+const products = [];
+for (const bucket of data.buckets || []) {
+  const area = AREA_BY_BUCKET[bucket.key];
+  if (!area) {
+    fail(FILES.targets, bucket.key, 'unknown bucket key — no area mapping');
+    continue;
+  }
+  for (const item of bucket.items || []) {
+    if (!item.productLabel) fail(FILES.targets, item.name, 'missing productLabel');
+    products.push({
+      name: item.name,
+      area,
+      label: `product:${item.productLabel}`,
+      aliases: item.legacyAliases || [],
+      core: bucket.key !== 'eco',
+    });
+  }
 }
+assertParsed(FILES.targets, products.length, 'products');
+const aliasOwner = new Map(); // alias -> product
+for (const p of products) for (const a of p.aliases) aliasOwner.set(a, p);
 
-console.log('✓ README.md -> Test targets matches data/targets.json.');
+// ---- 1. README generated block --------------------------------------------
 
-function extractBlock(readme) {
+{
+  const readme = await read(FILES.readme);
   const start = readme.indexOf(START);
   const end = readme.indexOf(END);
   if (start === -1 || end === -1 || end < start) {
-    throw new Error(`README.md is missing ${START} / ${END} markers.`);
+    fail(FILES.readme, 'targets block', `missing ${START} / ${END} markers`);
+  } else {
+    const current = readme.slice(start, end + END.length).trim();
+    const expected = (await renderTargets()).trim();
+    if (current !== expected) {
+      fail(FILES.readme, 'targets block', 'drifted from data/targets.json — run `node scripts/render-targets-readme.mjs --write`');
+    }
   }
-  return readme.slice(start, end + END.length);
+  summaries.push(`✓ ${FILES.readme}: generated block compared`);
+}
+
+// ---- 2. Form Product dropdown ---------------------------------------------
+
+{
+  const form = await read(FILES.form);
+  const options = extractDropdownOptions(form, 'product');
+  assertParsed(FILES.form, options.length, 'dropdown options');
+  const expected = [...products.map((p) => p.name), 'Other'];
+  const wanted = new Set(expected);
+  for (const name of expected) {
+    if (!options.includes(name)) fail(FILES.form, name, 'missing from the Product dropdown');
+  }
+  for (const opt of options) {
+    if (!wanted.has(opt)) {
+      const via = aliasOwner.get(opt);
+      fail(FILES.form, opt, via
+        ? `legacy alias of "${via.name}" must not appear in the dropdown`
+        : 'not a product in data/targets.json (stale option?)');
+    }
+  }
+  if (failures.length === 0 && expected.join('\n') !== options.join('\n')) {
+    fail(FILES.form, 'Product dropdown', `order drifted — expected: ${expected.join(' | ')}`);
+  }
+  summaries.push(`✓ ${FILES.form}: ${options.length} dropdown options checked`);
+}
+
+// ---- 3+4. Product -> area / product:* maps (workflow + setup script) ------
+
+for (const [file, varNames] of [
+  [FILES.workflow, { label: 'PRODUCT_LABEL', area: 'AREA' }],
+  [FILES.setup, { label: 'product_label', area: 'area' }],
+]) {
+  const text = await read(file);
+  const labelMap = extractCaseAssignments(text, varNames.label, /^product:[a-z0-9-]+$/);
+  const areaMap = extractCaseAssignments(text, varNames.area, /^area:[a-z0-9-]+$/);
+  assertParsed(file, labelMap.length, `${varNames.label} case arms`);
+  assertParsed(file, areaMap.length, `${varNames.area} case arms`);
+
+  const lookup = (map, name) =>
+    map.find((e) => (e.glob ? name.startsWith(e.pattern) : name === e.pattern));
+
+  for (const p of products) {
+    for (const name of [p.name, ...p.aliases]) {
+      const l = lookup(labelMap, name);
+      if (!l) fail(file, name, `no ${varNames.label} mapping`);
+      else if (l.value !== p.label) fail(file, name, `maps to ${l.value}, expected ${p.label}`);
+      const a = lookup(areaMap, name);
+      if (!a) fail(file, name, `no ${varNames.area} mapping`);
+      else if (a.value !== p.area) fail(file, name, `maps to ${a.value}, expected ${p.area}`);
+    }
+  }
+  for (const entry of [...labelMap, ...areaMap]) {
+    if (STRUCTURAL_PATTERNS.has(entry.pattern)) continue;
+    const known = products.some((p) =>
+      [p.name, ...p.aliases].some((n) => (entry.glob ? n.startsWith(entry.pattern) : n === entry.pattern)));
+    if (!known) fail(file, entry.pattern, 'maps a product unknown to data/targets.json (stale entry?)');
+  }
+  summaries.push(`✓ ${file}: ${labelMap.length} label + ${areaMap.length} area case arms checked`);
+}
+
+// ---- 5a. owners.json (core products only, by design) ----------------------
+
+{
+  const owners = JSON.parse(await read(FILES.owners)).owners || [];
+  assertParsed(FILES.owners, owners.length, 'owner entries');
+  const core = products.filter((p) => p.core);
+  for (const p of core) {
+    const entry = owners.find((o) => o.product === p.name);
+    if (!entry) fail(FILES.owners, p.name, 'core product has no owner entry');
+    else if (`area:${entry.area}` !== p.area) fail(FILES.owners, p.name, `area is "${entry.area}", expected "${p.area.replace('area:', '')}"`);
+  }
+  for (const o of owners) {
+    if (!core.some((p) => p.name === o.product)) {
+      const via = aliasOwner.get(o.product);
+      fail(FILES.owners, o.product, via
+        ? `stale entry — product renamed to "${via.name}"`
+        : 'entry does not match any core product (orphan)');
+    }
+  }
+  summaries.push(`✓ ${FILES.owners}: ${owners.length} owner entries checked against ${core.length} core products`);
+}
+
+// ---- 5b. labels.yml product:* set -----------------------------------------
+
+{
+  const labelsYml = await read(FILES.labels);
+  const declared = [...labelsYml.matchAll(/^- name: "(product:[a-z0-9-]+)"/gm)].map((m) => m[1]);
+  assertParsed(FILES.labels, declared.length, 'product:* labels');
+  const wanted = new Set(products.map((p) => p.label));
+  for (const label of wanted) {
+    if (!declared.includes(label)) fail(FILES.labels, label, 'missing product:* label');
+  }
+  for (const label of declared) {
+    if (!wanted.has(label)) fail(FILES.labels, label, 'label has no product in data/targets.json (stale?)');
+  }
+  summaries.push(`✓ ${FILES.labels}: ${declared.length} product:* labels checked`);
+}
+
+// ---- Verdict ---------------------------------------------------------------
+
+if (failures.length) {
+  for (const line of failures) console.error(line);
+  console.error(`✖ ${failures.length} inconsistenc${failures.length === 1 ? 'y' : 'ies'} across the target surfaces.`);
+  process.exit(1);
+}
+for (const line of summaries) console.log(line);
+console.log(`✓ ${products.length} products consistent across README, form, maps, owners, and labels.`);
+
+// ---- Helpers ---------------------------------------------------------------
+
+async function read(rel) {
+  return readFile(join(root, rel), 'utf8');
+}
+
+function assertParsed(file, count, what) {
+  if (count === 0) {
+    console.error(`✖ ${file} :: parser :: extracted 0 ${what} — file format changed? Refusing to pass on an empty read.`);
+    process.exit(1);
+  }
+}
+
+// Issue-form dropdown: anchored on `id: <id>`, then its `options:` list of
+// `- "..."` lines, ending at the next non-list key (e.g. `validations:`).
+function extractDropdownOptions(yaml, id) {
+  const lines = yaml.split('\n');
+  const out = [];
+  let inField = false;
+  let inOptions = false;
+  for (const line of lines) {
+    if (new RegExp(`^\\s*id:\\s*${id}\\s*$`).test(line)) { inField = true; continue; }
+    if (!inField) continue;
+    if (/^\s*options:\s*$/.test(line)) { inOptions = true; continue; }
+    if (inOptions) {
+      const m = line.match(/^\s*-\s*"([^"]+)"\s*$/);
+      if (m) { out.push(m[1]); continue; }
+      break; // end of the options list
+    }
+  }
+  return out;
+}
+
+// Shell case arms assigning VAR="value". Handles single-line arms
+// (`"X"|"Y"*) var="value" ;;`) and the two-line shape used in the workflow
+// (pattern line ending in `)`, assignment within the next 3 lines, comments
+// in between allowed).
+function extractCaseAssignments(text, varName, valueShape) {
+  const lines = text.split('\n');
+  const out = [];
+  const patternLine = /^\s*((?:"[^"]+"\*?\|)*"[^"]+"\*?)\)\s*(.*)$/;
+  const assignRe = new RegExp(`${varName}="([^"]+)"`);
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(patternLine);
+    if (!m) continue;
+    let assign = m[2].match(assignRe);
+    for (let j = i + 1; !assign && j <= i + 3 && j < lines.length; j++) {
+      if (/^\s*#/.test(lines[j])) continue; // comment between pattern and assignment
+      assign = lines[j].match(assignRe);
+      break;
+    }
+    if (!assign || !valueShape.test(assign[1])) continue;
+    for (const seg of m[1].matchAll(/"([^"]+)"(\*)?/g)) {
+      out.push({ pattern: seg[1], glob: Boolean(seg[2]), value: assign[1] });
+    }
+  }
+  return out;
 }


### PR DESCRIPTION
Closes #26.

## What

`data/targets.json` stays the single source of truth; the checker now validates five edges against it instead of one:

1. README targets block (existing logic, kept)
2. Submit Feedback **Product dropdown** (options + order)
3. `add-defects-to-board.yml` Product → area / product:* case arms
4. `setup-labels-and-board.sh` lockstep copy of the same maps
5. `data/owners.json` core entries + `labels.yml` product:* label set

targets.json items gain `productLabel` (drives the product:* label — slugs aren't derivable from names) and `legacyAliases` (retired names the body-parsing maps must still route, but no other surface may show). **Any source parsing to zero entries is a hard failure** — a format change breaks loudly instead of passing silently. `check-drift.yml` paths now cover all five surfaces.

## Why

The PandaClaw → Agent launchpad drift (#25/#27) shipped under a green CI because only the README edge was guarded. With this check, any of the five surfaces drifting fails the build and names the file and the product.

## Verification

- Positive: current repo → exit 0, per-surface counts printed (17 products / 18 dropdown options / 18+22 case arms / 8 owners / 17 labels)
- Negative ×7: seeded one drift per surface (README, dropdown, workflow map, setup map, owners, labels, plus a parser-anchor rename for the zero-parse guard) → each exits 1 naming file + product; state restored, exit 0
- `node --check`, ruby YAML, JSON parse, `git diff --check` all pass

Plan approved on #26; decision recorded as D010.