### PR TITLE
fix(triage): enforce status-label mutex and add drift sweep

### DIFF
--- a/.github/TRIAGE.md
+++ b/.github/TRIAGE.md
@@ -75,10 +75,19 @@ through labels and routed evidence instead of local PR/sub-issue workflows.
 Triage (filed) ⇄ Needs Info → Accepted → Routed → Closed (+ one resolution:*)
 ```
 
+**Changing status is a one-label action.** `status:*` labels are mutually exclusive —
+just **add** the new one and the [`add-defects-to-board`](./workflows/add-defects-to-board.yml)
+automation removes every other `status:*` and re-syncs the board. No manual "remove the
+old label" step. If you remove a status label and leave the issue with **zero**, automation
+restores `status:filed` and puts it back in **Triage**, so a defect always carries exactly
+one status. Two status changes that genuinely race are flagged with `needs:manual-label`
+plus an explanation comment (remove the stale label and it re-syncs). The daily
+[`triage-sweep`](#triage-sweep-daily-safety-net) catches any drift the live events miss.
+
 | Column / status label | Meaning | What triage does |
 |---|---|---|
 | `status:filed` (**Triage**) | New, unvalidated | Confirm/correct the auto-derived `area:*` and `product:*`. Try the repro from Details. |
-| `status:needs-info` (**Needs Info**) | Waiting on the tester | Repro incomplete but plausible — swap `status:filed` for this; the bot asks the tester to reply. No reply in **~7 days** → close as `resolution:rejected`. Reply arrives → back to `status:filed`. |
+| `status:needs-info` (**Needs Info**) | Waiting on the tester | Repro incomplete but plausible — add this label (automation drops the old status); the bot asks the tester to reply. No reply in **~7 days** → the daily sweep reminds, then close as `resolution:rejected`. Reply arrives → back to `status:filed`. |
 | `status:accepted` (**Accepted**) | Real + reproducible | Confirmed. **This is the state that counts toward rewards.** |
 | `status:routed` (**Routed**) | Sent upstream | Owner notified (SDK / docs / config / the product team). |
 | `status:closed` (**Closed**) | Closed — resolution says why | Apply exactly one `resolution:*` **before or together with** `status:closed`, plus a one-line reason. The bot turns the resolution into a precise message for the tester. |
@@ -95,6 +104,26 @@ to know whether their report counted):
 Area is about routing and reward scope: Ecosystem dApp issues are useful coverage
 outside the core reward ladder, while App Suite and 0G Infra are the core reward path.
 
+## Triage sweep (daily safety net)
+
+The live workflows only fire on label/issue events, so anything that depends on **time
+passing** or on **state drifting silently** needs a scheduled check. The
+[`triage-sweep`](./workflows/triage-sweep.yml) Action runs daily (**09:00 UTC**) and can be
+run on demand from the Actions tab (**Run workflow** → optional `stale_days`, default `7`).
+It only comments and labels — it never closes issues or touches the board, and it uses the
+default `GITHUB_TOKEN` (no `PROJECT_PAT`).
+
+- **needs-info timeouts** — for every open `status:needs-info` issue with no update in
+  ≥ `stale_days` days, it posts a deduped reminder that an unanswered needs-info issue is
+  closed as `resolution:rejected`. It **does not** auto-close — a maintainer still decides.
+- **State-machine consistency** — it flags, with `needs:manual-label` and an explanation
+  comment, any issue where the label state and the real state have drifted: an **open** issue
+  labelled `status:closed`; a **closed** defect with **no** `resolution:*`; or a **closed**
+  defect still carrying a `status:*` other than `status:closed`.
+
+Every run writes a summary (counts + issue numbers, or an explicit "0 found" with how many
+issues were scanned) to the workflow run's summary page.
+
 ## Labelling on intake
 
 Root cause and routing are **maintainer responsibilities** — the tester only supplies
@@ -108,9 +137,11 @@ Category, Product, Details, and Evidence.
    - 0G Hub / 0G Storage Scan / Chain Scan / 0G Code to Coin → `area:0g-infra`
    - TradeGPT / Jaine / Oku / AI Arena / CARV / Cygnus Finance / DataHive / Khalani / Merkl → `area:ecosystem`
    - Product = Other → no auto area/product; the issue carries `needs:manual-label` — assign by hand.
-2. **Status** — move `status:filed` → `status:accepted` once you reproduce it. If the repro
-   is incomplete but plausible, swap in `status:needs-info` (the bot asks the tester; ~7 days
-   without a reply → close as `resolution:rejected`). When closing, apply exactly one
+2. **Status** — just **add** the target `status:*` label; automation removes the previous one
+   and re-syncs the board (they are mutually exclusive — no manual un-labelling). Add
+   `status:accepted` once you reproduce it. If the repro is incomplete but plausible, add
+   `status:needs-info` (the bot asks the tester; ~7 days without a reply → the daily sweep
+   reminds, then close as `resolution:rejected`). When closing, apply exactly one
    `resolution:*` (`fixed` / `rejected` / `duplicate`) **before or together with**
    `status:closed` so the bot posts the precise outcome instead of the generic one.
 3. **Root cause** — when defects share an underlying cause, apply an `rc:<CODE>` label

--- a/.github/workflows/add-defects-to-board.yml
+++ b/.github/workflows/add-defects-to-board.yml
@@ -16,7 +16,7 @@ name: Add defects to board
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -27,15 +27,21 @@ jobs:
     # later labels (area:*, product:*, rc:*…), but keep Project Status in
     # sync when a maintainer changes the issue's single `status:*` label.
     # Re-runs are idempotent and do not re-stamp `status:filed` when one status
-    # label already exists. If a maintainer accidentally leaves multiple
-    # `status:*` labels, the job flags `needs:manual-label` and skips board sync.
+    # label already exists. Adding a `status:*` label auto-removes the others
+    # (status labels are mutually exclusive); those removals arrive as
+    # `unlabeled` events, which this job also handles — re-reading the remaining
+    # `status:*` and re-syncing the board (0 left → restore `status:filed`).
+    # If multiple `status:*` labels genuinely coexist (a concurrent race), the
+    # job flags `needs:manual-label`, comments why, and skips board sync.
     if: >-
       (contains(github.event.issue.labels.*.name, 'feedback') ||
        contains(github.event.issue.labels.*.name, 'defect')) &&
       (github.event.action == 'opened' ||
-       github.event.label.name == 'feedback' ||
-       github.event.label.name == 'defect' ||
-       startsWith(github.event.label.name, 'status:'))
+       (github.event.action == 'labeled' &&
+        (github.event.label.name == 'feedback' ||
+         github.event.label.name == 'defect')) ||
+       ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+        startsWith(github.event.label.name, 'status:')))
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.PROJECT_PAT }}
@@ -45,11 +51,30 @@ jobs:
       ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}
       EVENT_ACTION: ${{ github.event.action }}
+      TRIGGER_LABEL: ${{ github.event.label.name }}
       HAS_DEFECT: ${{ contains(github.event.issue.labels.*.name, 'defect') }}
     steps:
       - name: Route by Category and add Bug Reports to the board
         run: |
           set -euo pipefail
+
+          # Post (or update) an explanation comment whenever `needs:manual-label`
+          # is applied, so the reason lives on the issue — not only in the Actions
+          # log. Deduped by an HTML marker: the same PATCH-or-POST pattern as
+          # notify-status-change.yml, so re-runs update in place instead of piling
+          # up. The latest reason replaces any earlier one.
+          MANUAL_LABEL_MARKER="<!-- og-manual-label-reason -->"
+          comment_manual_label_reason() {
+            reason="$1"
+            body=$(printf '%s\n\n%s' "$MANUAL_LABEL_MARKER" "$reason")
+            cid=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
+              --jq ".[] | select(.body | contains(\"$MANUAL_LABEL_MARKER\")) | .id" | head -n 1)
+            if [ -n "$cid" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$cid" -f body="$body" >/dev/null
+            else
+              gh api --method POST "repos/$REPO/issues/$ISSUE_NUMBER/comments" -f body="$body" >/dev/null
+            fi
+          }
 
           # Parse GitHub issue-form markdown: field labels render as "### <Label>"
           # headings, so these strings must match the form labels byte-for-byte.
@@ -84,10 +109,36 @@ jobs:
             esac
           fi
 
+          # Status labels are mutually exclusive: a defect carries exactly one
+          # `status:*` at a time. When a maintainer ADDS a `status:*` label, drop
+          # every other `status:*` here so the board never sees ambiguous state —
+          # no more "remove the old one by hand". Each removal fires an
+          # `unlabeled` event that re-enters this job, but by then only one status
+          # remains, so that re-run just re-syncs the board (no label writes) and
+          # the single-status state is the fixed point — no loop.
+          if [ "$EVENT_ACTION" = "labeled" ]; then
+            case "$TRIGGER_LABEL" in
+              status:*)
+                current_status=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name' | grep '^status:' || true)
+                while IFS= read -r s; do
+                  [ -z "$s" ] && continue
+                  if [ "$s" != "$TRIGGER_LABEL" ]; then
+                    gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$s" >/dev/null
+                    echo "Removed superseded status label '$s' (kept '$TRIGGER_LABEL')."
+                  fi
+                done <<<"$current_status"
+                ;;
+            esac
+          fi
+
           # Keep label state in sync with the board state. This is idempotent and
           # covers issues that were manually labelled `defect` outside the form,
           # without adding a second status or pushing already-triaged issues back
-          # to Triage.
+          # to Triage. Re-read after any mutex removal above so the counts are
+          # current. This block also handles the `unlabeled` path: after a
+          # `status:*` is removed, 1 left → sync to it; 0 left → restore
+          # `status:filed` (Triage) to keep the single-status invariant; ≥2 left
+          # (a genuine race) → flag `needs:manual-label` and skip board sync.
           LABELS=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name' | tr '\n' ' ')
           status_labels=$(printf '%s\n' "$LABELS" | tr ' ' '\n' | grep '^status:' || true)
           status_count=$(printf '%s\n' "$status_labels" | sed '/^$/d' | wc -l | tr -d ' ')
@@ -102,6 +153,7 @@ jobs:
             status_list=$(printf '%s' "$status_labels" | tr '\n' ' ' | sed -E 's/[[:space:]]+$//')
             echo "::warning::Issue has multiple status labels: $status_list"
             gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs:manual-label" >/dev/null
+            comment_manual_label_reason "🏷️ **Needs a manual status label.** This issue currently carries multiple \`status:*\` labels ($status_list). A defect must have exactly one — this usually means two status changes raced. **Maintainer:** remove the stale \`status:*\` label(s) so only the correct one remains; the board Status and the tester notification will then re-sync automatically."
             board_status=""
           fi
 
@@ -175,6 +227,7 @@ jobs:
 
           if [ "$NEEDS_MANUAL" -eq 1 ]; then
             gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs:manual-label" >/dev/null
+            comment_manual_label_reason "🏷️ **Needs a manual area label.** Automation could not derive an \`area:*\` from this issue's Product (\`${PRODUCT:-unset}\`) — either Product is *Other* or the field did not match the known map. **Maintainer:** add the correct \`area:*\` (\`area:app-suite\` · \`area:0g-infra\` · \`area:ecosystem\`) and a \`product:*\` per [TRIAGE.md](../../blob/main/.github/TRIAGE.md#labelling-on-intake), then remove \`needs:manual-label\`."
           fi
 
           # Ecosystem dApp findings are useful coverage, but higher reward tiers
@@ -227,6 +280,7 @@ jobs:
             *)
               echo "::warning::Unknown status label: $board_status"
               gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs:manual-label" >/dev/null
+              comment_manual_label_reason "🏷️ **Needs a manual status label.** The status label \`$board_status\` does not map to a known board column. **Maintainer:** replace it with one of \`status:filed\` · \`status:needs-info\` · \`status:accepted\` · \`status:routed\` · \`status:closed\`, then remove \`needs:manual-label\`."
               exit 0 ;;
           esac
 

--- a/.github/workflows/notify-status-change.yml
+++ b/.github/workflows/notify-status-change.yml
@@ -51,6 +51,24 @@ jobs:
           LABELS=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name' | tr '\n' ' ')
           has() { case " $LABELS " in *" $1 "*) return 0 ;; *) return 1 ;; esac }
 
+          # Guard against the multi-status race window. add-defects-to-board.yml
+          # keeps status:* labels mutually exclusive, but during a two-change race
+          # the issue can transiently carry more than one. If this is a status:*
+          # notification and >1 status label is present, defer — commenting now
+          # could announce a status that is about to be auto-removed. Once the
+          # mutex converges to a single status, the resulting label event re-fires
+          # this workflow with a consistent picture. (resolution:* /
+          # needs:dapp-report-url notifications are unaffected.)
+          case "$LABEL" in
+            status:*)
+              STATUS_COUNT=$(printf '%s' "$LABELS" | tr ' ' '\n' | grep -c '^status:' || true)
+              if [ "${STATUS_COUNT:-0}" -gt 1 ]; then
+                echo "Issue #$ISSUE_NUMBER has $STATUS_COUNT status labels; deferring status comment until they converge."
+                exit 0
+              fi
+              ;;
+          esac
+
           ACCEPTED_MSG="✅ **Accepted** — triage reproduced and confirmed this defect. It counts toward your reward tier (rewards are on **accepted, deduped** core findings). See [LEVELS.md](../../blob/main/docs/LEVELS.md)."
           if has "area:ecosystem"; then
             ACCEPTED_MSG="✅ **Ecosystem coverage accepted** — thanks for confirming this. It helps ecosystem follow-up, but the higher L1–L3 rewards come from accepted **0G App Suite** and **0G Infra** bugs. If actionable, please also report it to the dApp's own channel. See [LEVELS.md](../../blob/main/docs/LEVELS.md)."

--- a/.github/workflows/triage-sweep.yml
+++ b/.github/workflows/triage-sweep.yml
@@ -1,0 +1,148 @@
+name: Triage sweep
+
+# A daily janitor for triage state that the event-driven workflows can't catch,
+# because they only fire on live label/issue events:
+#
+#   Sweep A — needs-info timeout: TRIAGE.md gives a tester ~7 days to reply to a
+#   status:needs-info issue before it is closed as resolution:rejected. Nothing
+#   fires on "time passed", so a stale needs-info issue would sit silently. This
+#   posts a dedup'd reminder (it does NOT auto-close — a human still decides).
+#
+#   Sweep B — state-machine consistency: the status:closed label and the issue's
+#   real open/closed state are independent actions and can drift. This flags the
+#   drift with needs:manual-label + an explanation comment for a maintainer.
+#
+# Read-only against the board: this uses the default GITHUB_TOKEN (issues:write)
+# to comment and label only — it never touches Projects v2, so no PROJECT_PAT.
+
+on:
+  schedule:
+    - cron: "0 9 * * *" # daily 09:00 UTC (offset from check-project-token's 07:00)
+  workflow_dispatch:
+    inputs:
+      stale_days:
+        description: "Days without an update before a needs-info issue is reminded"
+        required: false
+        default: "7"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      STALE_DAYS: ${{ github.event.inputs.stale_days || '7' }}
+    steps:
+      - name: Sweep needs-info timeouts and state-machine consistency
+        run: |
+          set -euo pipefail
+
+          # Post or update a marker-deduped comment (PATCH-or-POST, same pattern
+          # as notify-status-change.yml) so daily re-runs refresh in place instead
+          # of piling new comments on the issue.
+          post_or_update() {
+            number="$1"; marker="$2"; msg="$3"
+            body=$(printf '%s\n\n%s' "$marker" "$msg")
+            cid=$(gh api "repos/$REPO/issues/$number/comments" --paginate \
+              --jq ".[] | select(.body | contains(\"$marker\")) | .id" | head -n 1)
+            if [ -n "$cid" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$cid" -f body="$body" >/dev/null
+            else
+              gh api --method POST "repos/$REPO/issues/$number/comments" -f body="$body" >/dev/null
+            fi
+          }
+
+          summary() { printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"; }
+
+          # ---- Sweep A: needs-info timeout reminders --------------------------
+          CUTOFF=$(date -u -d "$STALE_DAYS days ago" +%s)
+          NEEDS_INFO_JSON=$(gh issue list --repo "$REPO" --state open \
+            --label "status:needs-info" --limit 500 --json number,updatedAt,title)
+          NEEDS_INFO_TOTAL=$(printf '%s' "$NEEDS_INFO_JSON" | jq 'length')
+
+          stale_nums=""
+          stale_count=0
+          # Tab-separated number<TAB>updatedAt so titles with spaces don't split.
+          while IFS=$'\t' read -r num updated; do
+            [ -z "$num" ] && continue
+            updated_epoch=$(date -u -d "$updated" +%s)
+            if [ "$updated_epoch" -le "$CUTOFF" ]; then
+              post_or_update "$num" "<!-- og-triage-sweep:needs-info-stale -->" \
+                "⏰ **Reminder — this bug is waiting on more info.** It was moved to \`status:needs-info\` and has had no update in over **${STALE_DAYS} days**. Per [TRIAGE.md](../../blob/main/.github/TRIAGE.md), a needs-info issue with no reply is closed as \`resolution:rejected\` — a reply with the missing repro details (exact steps, environment, screenshots/recording) keeps your potential reward credit alive. This is an automated reminder; it does **not** auto-close the issue."
+              stale_nums="$stale_nums #$num"
+              stale_count=$((stale_count + 1))
+            fi
+          done < <(printf '%s' "$NEEDS_INFO_JSON" | jq -r '.[] | [(.number|tostring), .updatedAt] | @tsv')
+
+          # ---- Sweep B: state-machine consistency ----------------------------
+          # B1: open issue carrying status:closed (label says closed, issue isn't).
+          OPEN_CLOSED=$(gh issue list --repo "$REPO" --state open \
+            --label "status:closed" --limit 500 --json number --jq '.[].number')
+
+          # Closed defects, for B2/B3 label checks.
+          CLOSED_DEFECTS=$(gh issue list --repo "$REPO" --state closed \
+            --label "defect" --limit 1000 --json number,labels)
+          CLOSED_DEFECTS_TOTAL=$(printf '%s' "$CLOSED_DEFECTS" | jq 'length')
+
+          # B2: closed defect with no resolution:* label.
+          NO_RESOLUTION=$(printf '%s' "$CLOSED_DEFECTS" | jq -r \
+            '.[] | select([.labels[].name | startswith("resolution:")] | any | not) | .number')
+
+          # B3: closed defect carrying a status:* label that is not status:closed.
+          STALE_STATUS=$(printf '%s' "$CLOSED_DEFECTS" | jq -r \
+            '.[] | select(any(.labels[].name; startswith("status:") and . != "status:closed")) | .number')
+
+          flag() { # number, marker, message
+            gh issue edit "$1" --repo "$REPO" --add-label "needs:manual-label" >/dev/null
+            post_or_update "$1" "$2" "$3"
+          }
+
+          b1_nums=""; b1_count=0
+          for n in $OPEN_CLOSED; do
+            [ -z "$n" ] && continue
+            flag "$n" "<!-- og-triage-sweep:open-with-closed -->" \
+              "🏷️ **State mismatch — open issue labelled \`status:closed\`.** The \`status:closed\` label and the issue's real open/closed state have drifted. **Maintainer:** either close this issue (if it is truly done) or remove \`status:closed\` and set the correct \`status:*\`, then remove \`needs:manual-label\`."
+            b1_nums="$b1_nums #$n"; b1_count=$((b1_count + 1))
+          done
+
+          b2_nums=""; b2_count=0
+          for n in $NO_RESOLUTION; do
+            [ -z "$n" ] && continue
+            flag "$n" "<!-- og-triage-sweep:closed-no-resolution -->" \
+              "🏷️ **Closed defect without a resolution.** This defect is closed but carries no \`resolution:*\` label, so the tester was never told whether it counted. **Maintainer:** add exactly one \`resolution:fixed\` / \`resolution:rejected\` / \`resolution:duplicate\` per [TRIAGE.md](../../blob/main/.github/TRIAGE.md), then remove \`needs:manual-label\`."
+            b2_nums="$b2_nums #$n"; b2_count=$((b2_count + 1))
+          done
+
+          b3_nums=""; b3_count=0
+          for n in $STALE_STATUS; do
+            [ -z "$n" ] && continue
+            flag "$n" "<!-- og-triage-sweep:closed-stale-status -->" \
+              "🏷️ **Closed defect with a non-closed status label.** This issue is closed but still carries a \`status:*\` other than \`status:closed\`. **Maintainer:** set \`status:closed\` (adding a new \`status:*\` auto-removes the stale one) or reopen the issue, then remove \`needs:manual-label\`."
+            b3_nums="$b3_nums #$n"; b3_count=$((b3_count + 1))
+          done
+
+          # ---- Summary (anti-empty-green: always report what was scanned) -----
+          consistency_total=$((b1_count + b2_count + b3_count))
+          summary "## Triage sweep"
+          summary ""
+          summary "Scanned **${NEEDS_INFO_TOTAL}** open \`status:needs-info\` issue(s) and **${CLOSED_DEFECTS_TOTAL}** closed defect(s)."
+          summary ""
+          summary "### A. needs-info timeouts (≥ ${STALE_DAYS} days)"
+          if [ "$stale_count" -gt 0 ]; then
+            summary "- ${stale_count} reminded:${stale_nums}"
+          else
+            summary "- 0 stale needs-info issues."
+          fi
+          summary ""
+          summary "### B. State-machine consistency"
+          if [ "$consistency_total" -gt 0 ]; then
+            [ "$b1_count" -gt 0 ] && summary "- ${b1_count} open + \`status:closed\`:${b1_nums}"
+            [ "$b2_count" -gt 0 ] && summary "- ${b2_count} closed defect(s) missing \`resolution:*\`:${b2_nums}"
+            [ "$b3_count" -gt 0 ] && summary "- ${b3_count} closed defect(s) with a non-closed \`status:*\`:${b3_nums}"
+          else
+            summary "- 0 inconsistencies found."
+          fi


### PR DESCRIPTION
Closes #29

按 D011 批准方案实现：
- add-defects-to-board.yml 状态互斥：新 `status:*` 自动摘旧，维持"恰有一个状态"不变量
- 触发器补 unlabeled：剩 1 同步看板；剩 0 回退 status:filed/Triage
- needs:manual-label 附 marker 去重的解释评论
- 新增 triage-sweep.yml 每日巡检（needs-info 超时提醒 + closed/标签漂移检测，只提醒不自动关闭）
- TRIAGE.md 同步（D011 的 Public sync PENDING 随本 PR 清偿）

验证：模拟分支测试 8/8 通过；E2E 验收按 D011 约定在合并后线上进行（issues 事件 workflow 仅执行默认分支版本）。