### PR TITLE
fix(intake): 令牌分离 —— PROJECT_PAT 失效只降级看板，不再吞掉整条 intake

### DIFF
--- a/.github/workflows/add-defects-to-board.yml
+++ b/.github/workflows/add-defects-to-board.yml
@@ -11,8 +11,12 @@ name: Add defects to board
 # Manually adding `defect` (including to legacy old-form issues) routes through
 # the same board logic.
 #
-# Requires a repo secret `PROJECT_PAT` — a token with `project` + `repo` +
-# `read:org` scope. The default GITHUB_TOKEN cannot write an org Projects v2 board.
+# Token split. Intake — labels, Category routing, and the tester-facing
+# acknowledgement comments — runs on the default GITHUB_TOKEN. Only the Projects
+# v2 board writes use the `PROJECT_PAT` secret (`project` + `repo` + `read:org`),
+# because the default token cannot write an org board. When PROJECT_PAT is dead
+# the board sync degrades to a warning and intake still completes — see #66 for
+# what happened when it could not.
 
 on:
   issues:
@@ -20,6 +24,7 @@ on:
 
 permissions:
   contents: read
+  issues: write # intake (labels + acknowledgement comments) runs on GITHUB_TOKEN
 
 jobs:
   add-to-board:
@@ -44,7 +49,11 @@ jobs:
         startsWith(github.event.label.name, 'status:')))
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.PROJECT_PAT }}
+      # Two tokens, never mixed. GH_TOKEN is the default token and covers every
+      # intake action; PROJECT_PAT is passed explicitly to the board mutations
+      # at the end and nowhere else.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
       OWNER: 0gfoundation
       REPO: ${{ github.repository }}
       PROJECT_NUMBER: "19"
@@ -270,11 +279,53 @@ jobs:
             echo "Issue has ambiguous status labels; skipped board Status update."
             exit 0
           fi
+          # Map the status label to its board column. Pure bash — no token, no
+          # network. An unknown status is an INTAKE problem (a bad label), so it
+          # is flagged here on GITHUB_TOKEN and never reaches the board sync.
+          case "$board_status" in
+            "status:filed")      BOARD_COLUMN="Triage" ;;
+            "status:needs-info") BOARD_COLUMN="Needs Info" ;;
+            "status:accepted")   BOARD_COLUMN="Accepted" ;;
+            "status:routed")     BOARD_COLUMN="Routed" ;;
+            "status:closed")     BOARD_COLUMN="Closed" ;;
+            *)
+              echo "::warning::Unknown status label: $board_status"
+              gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs:manual-label" >/dev/null
+              comment_manual_label_reason "🏷️ **Needs a manual status label.** The status label \`$board_status\` does not map to a known board column. **Maintainer:** replace it with one of \`status:filed\` · \`status:needs-info\` · \`status:accepted\` · \`status:routed\` · \`status:closed\`, then remove \`needs:manual-label\`."
+              exit 0 ;;
+          esac
 
-          # Resolve the board id, Status field id, and Status option ids at runtime,
-          # so this keeps working even if the board is recreated.
-          IFS=$'\037' read -r PROJECT_ID FIELD_ID TRIAGE_OPTION_ID NEEDS_INFO_OPTION_ID ACCEPTED_OPTION_ID ROUTED_OPTION_ID CLOSED_OPTION_ID < <(
-            gh api graphql -f query='
+          # ---- Board sync — the ONLY part that needs PROJECT_PAT --------------
+          # Everything above has already landed: labels, routing, and the
+          # tester-facing acknowledgement. So a dead PAT must degrade the BOARD
+          # ONLY.
+          #
+          # It did not use to. PROJECT_PAT was this job's top-level GH_TOKEN, so
+          # when it expired on 2026-07-23 the very first `gh issue view` returned
+          # 401 and `set -e` killed the run before any of the above ran — a
+          # tester's bug report got no labels, no acknowledgement, nothing at all,
+          # for 36 days (#66). Board failure must never become intake failure.
+          board_skip() {
+            echo "::warning::Board sync skipped for #$ISSUE_NUMBER: $1"
+            {
+              echo "- **#$ISSUE_NUMBER** — intake completed (labels + acknowledgement); **board sync skipped**: $1"
+              echo "  - Back-fill once PROJECT_PAT is restored: \`bash scripts/setup-labels-and-board.sh\`"
+            } >>"${GITHUB_STEP_SUMMARY:-/dev/null}"
+          }
+
+          sync_board() {
+            if [ -z "${PROJECT_PAT:-}" ]; then
+              board_skip "PROJECT_PAT is empty or unset"
+              return 0
+            fi
+
+            # Resolve the board id, Status field id, and Status options at runtime,
+            # so this keeps working even if the board is recreated. Options come
+            # back as name=id pairs and are matched in bash, because `gh --jq`
+            # takes no arguments to pass the wanted column into.
+            local raw PROJECT_ID FIELD_ID OPTION_ID ITEM_ID kv
+            local -a parts
+            if ! raw=$(GH_TOKEN="$PROJECT_PAT" gh api graphql -f query='
               query($l:String!,$n:Int!){
                 organization(login:$l){ projectV2(number:$n){
                   id
@@ -283,49 +334,51 @@ jobs:
                   }
                 }}
               }' -F l="$OWNER" -F n="$PROJECT_NUMBER" \
-              --jq '.data.organization.projectV2 as $p | [
-                $p.id,
-                $p.field.id,
-                ([$p.field.options[] | select(.name=="Triage") | .id][0] // ""),
-                ([$p.field.options[] | select(.name=="Needs Info") | .id][0] // ""),
-                ([$p.field.options[] | select(.name=="Accepted") | .id][0] // ""),
-                ([$p.field.options[] | select(.name=="Routed") | .id][0] // ""),
-                ([$p.field.options[] | select(.name=="Closed") | .id][0] // "")
-              ] | join("\u001f")'
-          )
+              --jq '.data.organization.projectV2 as $p
+                    | [$p.id, $p.field.id] + [$p.field.options[] | .name + "=" + .id]
+                    | join("\u001f")' 2>&1); then
+              board_skip "PROJECT_PAT could not query Project #$PROJECT_NUMBER (revoked, expired, or missing project+read:org scope)"
+              return 0
+            fi
 
-          if [ -z "${PROJECT_ID:-}" ] || [ -z "${FIELD_ID:-}" ] || [ -z "${TRIAGE_OPTION_ID:-}" ] || [ -z "${NEEDS_INFO_OPTION_ID:-}" ] || [ -z "${ACCEPTED_OPTION_ID:-}" ] || [ -z "${ROUTED_OPTION_ID:-}" ] || [ -z "${CLOSED_OPTION_ID:-}" ]; then
-            echo "Could not resolve the board Status field/options — is the board configured?" >&2
-            exit 1
-          fi
+            IFS=$'\037' read -r -a parts <<<"$raw" || true
+            PROJECT_ID="${parts[0]:-}"
+            FIELD_ID="${parts[1]:-}"
+            OPTION_ID=""
+            # Explicit if, not `[ ... ] && x=y`: a false test as the loop's last
+            # command becomes the loop's exit code and trips errexit (E007/#35).
+            for kv in "${parts[@]:2}"; do
+              if [ "${kv%%=*}" = "$BOARD_COLUMN" ]; then OPTION_ID="${kv#*=}"; fi
+            done
 
-          case "$board_status" in
-            "status:filed") OPTION_ID="$TRIAGE_OPTION_ID" ;;
-            "status:needs-info") OPTION_ID="$NEEDS_INFO_OPTION_ID" ;;
-            "status:accepted") OPTION_ID="$ACCEPTED_OPTION_ID" ;;
-            "status:routed") OPTION_ID="$ROUTED_OPTION_ID" ;;
-            "status:closed") OPTION_ID="$CLOSED_OPTION_ID" ;;
-            *)
-              echo "::warning::Unknown status label: $board_status"
-              gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs:manual-label" >/dev/null
-              comment_manual_label_reason "🏷️ **Needs a manual status label.** The status label \`$board_status\` does not map to a known board column. **Maintainer:** replace it with one of \`status:filed\` · \`status:needs-info\` · \`status:accepted\` · \`status:routed\` · \`status:closed\`, then remove \`needs:manual-label\`."
-              exit 0 ;;
-          esac
+            if [ -z "$PROJECT_ID" ] || [ -z "$FIELD_ID" ] || [ -z "$OPTION_ID" ]; then
+              board_skip "could not resolve the board Status field or its '$BOARD_COLUMN' column — token scope, or the board was reconfigured"
+              return 0
+            fi
 
-          # Add the issue (no-op if already on the board) and capture the item id.
-          ITEM_ID=$(gh api graphql -f query='
-            mutation($p:ID!,$c:ID!){
-              addProjectV2ItemById(input:{projectId:$p,contentId:$c}){ item { id } }
-            }' -F p="$PROJECT_ID" -F c="$ISSUE_NODE_ID" \
-            --jq '.data.addProjectV2ItemById.item.id')
+            # Add the issue (no-op if already on the board) and capture the item id.
+            if ! ITEM_ID=$(GH_TOKEN="$PROJECT_PAT" gh api graphql -f query='
+              mutation($p:ID!,$c:ID!){
+                addProjectV2ItemById(input:{projectId:$p,contentId:$c}){ item { id } }
+              }' -F p="$PROJECT_ID" -F c="$ISSUE_NODE_ID" \
+              --jq '.data.addProjectV2ItemById.item.id' 2>&1) || [ -z "$ITEM_ID" ]; then
+              board_skip "could not add #$ISSUE_NUMBER to the board"
+              return 0
+            fi
 
-          # Sync board Status to the issue status label.
-          gh api graphql -f query='
-            mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){
-              updateProjectV2ItemFieldValue(input:{
-                projectId:$p, itemId:$i, fieldId:$f,
-                value:{ singleSelectOptionId:$o }
-              }){ projectV2Item { id } }
-            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$FIELD_ID" -F o="$OPTION_ID" >/dev/null
+            # Sync board Status to the issue status label.
+            if ! GH_TOKEN="$PROJECT_PAT" gh api graphql -f query='
+              mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){
+                updateProjectV2ItemFieldValue(input:{
+                  projectId:$p, itemId:$i, fieldId:$f,
+                  value:{ singleSelectOptionId:$o }
+                }){ projectV2Item { id } }
+              }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$FIELD_ID" -F o="$OPTION_ID" >/dev/null 2>&1; then
+              board_skip "could not set board Status to '$BOARD_COLUMN' for #$ISSUE_NUMBER"
+              return 0
+            fi
 
-          echo "Issue #$ISSUE_NUMBER added to the board with Status synced from $board_status."
+            echo "Issue #$ISSUE_NUMBER added to the board with Status '$BOARD_COLUMN' (from $board_status)."
+          }
+
+          sync_board

--- a/.github/workflows/check-project-token.yml
+++ b/.github/workflows/check-project-token.yml
@@ -1,11 +1,25 @@
 name: Check PROJECT_PAT health
 
-# add-defects-to-board.yml depends on the PROJECT_PAT secret to write the org
-# Projects v2 board. If that token is revoked or expires, auto-add silently stops
-# (issues still get the `defect` label, they just never reach the board). This
-# workflow makes that failure loud: a daily read-only probe of Project #19 that
-# fails visibly — and can email the repo admins via the normal Actions
-# failure notification — when the token can no longer reach the board.
+# add-defects-to-board.yml needs the PROJECT_PAT secret to write the org
+# Projects v2 board; the default GITHUB_TOKEN cannot. If that token is revoked
+# or expires, board sync degrades — so this daily read-only probe of Project #19
+# checks it before a tester does.
+#
+# The probe alone was not enough. It ran red for 36 consecutive days
+# (2026-07-23 → 2026-08-27) with `gh: Bad credentials (HTTP 401)` and nobody
+# noticed, because a red run only exists on the Actions page. A health check
+# with no outlet is not a health check. So the probe now also OPENS AN ISSUE
+# when the token is unhealthy, and closes it again once the token recovers.
+#
+# Two tokens, never mixed:
+#   PROJECT_PAT  — the probe itself (the thing under test)
+#   GITHUB_TOKEN — the alert issue (open / update / close)
+#
+# The alert issue deliberately carries NO labels. `feedback` / `defect` would
+# pull it into add-defects-to-board.yml, `signup` (or a `[signup]` title prefix)
+# into confirm-signup.yml, and `status:*` / `resolution:*` into
+# notify-status-change.yml. A CI alert must not enter the tester pipeline or the
+# reward export.
 #
 # Rotate with: gh secret set PROJECT_PAT --repo 0gfoundation/0g-testing-hub
 # then re-run scripts/setup-labels-and-board.sh to safely back-fill missed open
@@ -18,46 +32,106 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   probe:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.PROJECT_PAT }}
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
       OWNER: 0gfoundation
       PROJECT_NUMBER: "19"
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Probe Project #19 with PROJECT_PAT
         run: |
-          set -euo pipefail
+          # No `-e`: a failed probe is the interesting case and must still reach
+          # the alerting block below. The step's exit code is set explicitly at
+          # the end so a broken token still shows up red in Actions.
+          set -uo pipefail
 
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::PROJECT_PAT is empty or unset — auto-add to the board cannot work." >&2
+          FAIL_REASON=""
+
+          # Read-only: resolve the board id and the Triage option — exactly what
+          # add-defects-to-board.yml needs at runtime, so a green probe means the
+          # board-sync path has a working token.
+          if [ -z "${PROJECT_PAT:-}" ]; then
+            FAIL_REASON="PROJECT_PAT is empty or unset — the secret is missing from this repository."
+          elif ! PROBE_OUT=$(GH_TOKEN="$PROJECT_PAT" gh api graphql -f query='
+            query($l:String!,$n:Int!){
+              organization(login:$l){ projectV2(number:$n){
+                id
+                field(name:"Status"){
+                  ... on ProjectV2SingleSelectField { options { id name } }
+                }
+              }}
+            }' -F l="$OWNER" -F n="$PROJECT_NUMBER" \
+            --jq '.data.organization.projectV2 | "\(.id) \(.field.options[] | select(.name=="Triage") | .id)"' 2>&1); then
+            FAIL_REASON="PROJECT_PAT could not query Project #${PROJECT_NUMBER} — token likely revoked, expired, or missing project+read:org scope. API said: $(printf '%s' "$PROBE_OUT" | head -c 300)"
+          else
+            read -r PROJECT_ID OPTION_ID <<<"$PROBE_OUT" || true
+            if [ -z "${PROJECT_ID:-}" ] || [ -z "${OPTION_ID:-}" ]; then
+              FAIL_REASON="Resolved an empty project/Triage id — token may lack scope or the board was reconfigured."
+            fi
+          fi
+
+          # Find a still-open alert from an earlier run. Marker-in-body rather
+          # than a label (see header) or GitHub search (which does not index HTML
+          # comments); the repo's open-issue count is small enough to scan.
+          MARKER="<!-- og-pat-health-alert -->"
+          existing=$(gh issue list --repo "$REPO" --state open --limit 100 --json number,body \
+            --jq "[.[] | select(.body | contains(\"$MARKER\")) | .number] | first // empty")
+
+          if [ -n "$FAIL_REASON" ]; then
+            body=$(cat <<EOF
+          $MARKER
+
+          ⚠️ **PROJECT_PAT cannot reach Project #${PROJECT_NUMBER} — board automation is degraded.**
+
+          - **Reason:** ${FAIL_REASON}
+          - **Last probe:** ${RUN_URL}
+
+          ### Impact
+
+          New Bug Reports still get their labels and their intake acknowledgement
+          (that path runs on \`GITHUB_TOKEN\`), but they do **not** reach the board.
+          Triage has to work from the issue list until the token is restored.
+
+          ### Fix
+
+          1. Mint a replacement token:
+             - **Classic PAT** — scopes \`repo\` + \`project\` + \`read:org\`, or
+             - **Fine-grained PAT** — resource owner \`${OWNER}\`, *Repository permissions → Issues: Read and write*, *Organization permissions → Projects: Read and write*.
+          2. \`gh secret set PROJECT_PAT --repo ${REPO}\`
+          3. Back-fill what was missed: \`bash scripts/setup-labels-and-board.sh\`
+             (safe — it does not downgrade existing status labels).
+
+          This issue updates itself on each failed probe and **closes automatically**
+          once a probe succeeds.
+          EOF
+          )
+            if [ -n "$existing" ]; then
+              gh issue edit "$existing" --repo "$REPO" --body "$body" >/dev/null
+              echo "Updated existing alert issue #${existing}."
+            else
+              created=$(gh issue create --repo "$REPO" \
+                --title "chore(ci): PROJECT_PAT is unhealthy — board automation degraded" \
+                --body "$body")
+              echo "Opened alert issue: ${created}"
+            fi
+            echo "::error::${FAIL_REASON}" >&2
             exit 1
           fi
 
-          # Read-only: resolve the board id, Status field, and the Triage option.
-          # This is exactly what add-defects-to-board.yml needs at runtime, so if it
-          # succeeds here the auto-add path has a working token.
-          read -r PROJECT_ID OPTION_ID < <(
-            gh api graphql -f query='
-              query($l:String!,$n:Int!){
-                organization(login:$l){ projectV2(number:$n){
-                  id
-                  field(name:"Status"){
-                    ... on ProjectV2SingleSelectField { options { id name } }
-                  }
-                }}
-              }' -F l="$OWNER" -F n="$PROJECT_NUMBER" \
-              --jq '.data.organization.projectV2 | "\(.id) \(.field.options[] | select(.name=="Triage") | .id)"'
-          ) || {
-            echo "::error::PROJECT_PAT could not query Project #$PROJECT_NUMBER — token likely revoked, expired, or missing project+read:org scope." >&2
-            exit 1
-          }
+          echo "PROJECT_PAT healthy: resolved Project #${PROJECT_NUMBER} (${PROJECT_ID}) with a Triage column."
 
-          if [ -z "${PROJECT_ID:-}" ] || [ -z "${OPTION_ID:-}" ]; then
-            echo "::error::Resolved an empty project/Triage id — token may lack scope or the board was reconfigured." >&2
-            exit 1
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" \
+              --body "✅ **Recovered** — PROJECT_PAT can reach Project #${PROJECT_NUMBER} again. Probe: ${RUN_URL}
+
+          If any defects were filed while the token was down, back-fill the board with \`bash scripts/setup-labels-and-board.sh\`."
+            gh issue close "$existing" --repo "$REPO" >/dev/null
+            echo "Closed alert issue #${existing} — token recovered."
           fi
-
-          echo "PROJECT_PAT healthy: resolved Project #$PROJECT_NUMBER ($PROJECT_ID) with a Triage column."


### PR DESCRIPTION
Closes #66
Closes #67

## 问题

`PROJECT_PAT` 自 2026-07-23 失效，`check-project-token` 连续 **36 天** 报 `gh: Bad credentials (HTTP 401)`。

但真正的伤害不在看板。`add-defects-to-board.yml` 把 PAT 设成了 **job 级** `GH_TOKEN`，脚本是 `set -euo pipefail`，第一条命令就是 `gh issue view` —— 401 直接掀掉整个 job。测试者提交 Bug Report 后得到的是**彻底沉默**：无标签、无 D020 确认评论、不进看板。

而 36 次红色 run 只存在于 Actions 页面，没有任何出口，所以没人知道。

## 改动

**`add-defects-to-board.yml` — 令牌分离**

intake（读表单 body、Category 路由、全部标签写入、D020 确认评论）改走 `GITHUB_TOKEN`（补 `permissions: issues: write`）。只有三条 Projects v2 GraphQL 逐调用带 `PROJECT_PAT`。

看板段收进 `sync_board()`，PAT 空 / 401 / 解析失败一律 `::warning::` + step summary 记一行（含回填命令 `scripts/setup-labels-and-board.sh`）后 `return 0`。**看板失败不再等于 intake 失败。**

D020 的评论逻辑、marker 去重、状态互斥、`needs:manual-label` 解释评论一行未改，只换了脚下的凭据。

**`check-project-token.yml` — 补出口**

探测逻辑不动（它 36 次都报准了）。失败时用 marker `<!-- og-pat-health-alert -->` 去重地开/更新一个告警 issue，恢复时评论并自动关闭。

告警 issue **不带任何标签**——`feedback`/`defect` 会被 `add-defects-to-board` 捡走，`signup`（或 `[signup]` 标题前缀）会触发 `confirm-signup`，`status:*` 会触发 `notify-status-change`。CI 告警不得进入测试者管线。

## 验证

| 检查 | 结果 |
|---|---|
| `add-defects` stub 三场景（empty / bad / good PAT）| **30/30** — intake 三场景均完成且 exit 0，降级仅在坏 PAT 下记录 |
| `check-project-token` 四个状态转换 | **16/16** — 建 / 更新不重复 / 恢复关闭 / 健康无动作 |
| **修复前对照**（旧代码 + 坏 PAT）| exit **1**，仅 1 次 gh 调用，**0** 标签，**0** 评论 —— 精确复现线上故障 |
| `check-targets-drift.mjs` | exit 0（15 产品五面一致） |
| `git diff --check` | exit 0 |
| 奖励导出 | 输出逐字不变 |
| YAML 解析 / 内嵌 `bash -n` | 两文件均 exit 0 |

## 合并后待办

1. 重签 `PROJECT_PAT`（classic: `repo`+`project`+`read:org`；fine-grained: org Projects R/W）
2. `bash scripts/setup-labels-and-board.sh` 回填断档期间的 open defect
3. 线上 e2e：一个 TEST feedback issue 走完 Bug Report 路径，验证标签 + ack + 看板三者齐全

## 未在本 PR 范围

同轮测试还定位了 4 个 DX 缺陷（signup 预填模板漂移、checkbox 混淆用户动作与系统状态、signup 停滞无巡检、L0 桥 canonical 排序与 confirm-signup 相反），按批准的粒度挂起，未混入本 PR。